### PR TITLE
pin build-custom since it is being deprecated

### DIFF
--- a/.github/workflows/e2e_custom_cl.yml
+++ b/.github/workflows/e2e_custom_cl.yml
@@ -13,15 +13,13 @@ jobs:
   e2e_custom_build_custom_chainlink_image:
     name: E2E Custom Build Custom CL Image
     # target branch can't be set as var, it's from where we getting pipeline code
-    uses: smartcontractkit/chainlink/.github/workflows/build-custom.yml@develop
+    uses: smartcontractkit/chainlink/.github/workflows/build-custom.yml@200b90865b024d7139e839f6cfc0b318fecab1af # develop on 18/07/2022 and will be deprecated
     with:
       cl_repo: smartcontractkit/chainlink
       cl_ref: ${{ github.event.inputs.cl_branch_ref }}
       # commit of the caller branch
       dep_starknet_sha: ${{ github.sha }}
     secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.QA_AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.QA_AWS_SECRET_KEY }}
       AWS_REGION: ${{ secrets.QA_AWS_REGION }}
       AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
       QA_KUBECONFIG: ${{ secrets.QA_KUBECONFIG }}
@@ -42,8 +40,6 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.QA_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.QA_AWS_SECRET_KEY }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
           role-to-assume: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           role-duration-seconds: 3600


### PR DESCRIPTION
Pinning this for now since it will be removed shortly and I don't want development on starknet to accidentally be halted. There is a ticket to use the new actions in progress by @AnieeG so this pin should just be a short term stop gap.