### PR TITLE
parse ocr2 onchain key prefix

### DIFF
--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
@@ -19,10 +19,16 @@ type ContractInput = [
 ]
 
 const makeContractInput = async (input: SetConfigInput): Promise<ContractInput> => {
-  const oracles: Oracle[] = input.signers.map((o, i) => ({
-    signer: input.signers[i].replace('ocr2on_starknet_', '0x'),
-    transmitter: input.transmitters[i],
-  }))
+  const oracles: Oracle[] = input.signers.map((o, i) => {
+    // standard format from chainlink node ocr2on_starknet_<key> (no 0x prefix)
+    let signer = input.signers[i].replace('ocr2on_starknet_', '') // replace prefix if present
+    signer = signer.startsWith('0x') ? signer : '0x' + signer // prepend 0x if missing
+
+    return {
+      signer,
+      transmitter: input.transmitters[i],
+    }
+  })
   const { offchainConfig } = await encoding.serializeOffchainConfig(input.offchainConfig, input.secret)
   return [oracles, new BN(input.f).toNumber(), input.onchainConfig, 2, bytesToFelts(offchainConfig)]
 }

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
@@ -20,7 +20,7 @@ type ContractInput = [
 
 const makeContractInput = async (input: SetConfigInput): Promise<ContractInput> => {
   const oracles: Oracle[] = input.signers.map((o, i) => ({
-    signer: input.signers[i],
+    signer: input.signers[i].replace('ocr2on_starknet_', '0x'),
     transmitter: input.transmitters[i],
   }))
   const { offchainConfig } = await encoding.serializeOffchainConfig(input.offchainConfig, input.secret)

--- a/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
@@ -15,10 +15,10 @@ import { Contract } from 'starknet'
 import { BN } from '@chainlink/gauntlet-core/dist/utils'
 
 const signers = [
-  '0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603730',
-  '0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603731',
-  '0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603732',
-  '0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603733',
+  'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603730',
+  'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603731',
+  'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603732',
+  'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603733',
 ]
 
 const transmitters = [

--- a/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
@@ -16,8 +16,8 @@ import { BN } from '@chainlink/gauntlet-core/dist/utils'
 
 const signers = [
   'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603730',
-  'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603731',
-  'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603732',
+  'ocr2on_starknet_0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603731',
+  '0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603732',
   'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603733',
 ]
 

--- a/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
@@ -15,10 +15,10 @@ import { Contract } from 'starknet'
 import { BN } from '@chainlink/gauntlet-core/dist/utils'
 
 const signers = [
-  'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603730',
-  'ocr2on_starknet_0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603731',
-  '0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603732',
-  'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603733',
+  'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603730', // ocr2on_starknet_<key>
+  'ocr2on_starknet_0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603731', // ocr2on_starknet_0x<key>
+  '0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603732', // 0x<key>
+  '04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603733', // <key>
 ]
 
 const transmitters = [


### PR DESCRIPTION
the ocr2 onchain keyring is returned from the CL node as: `ocr2on_starknet_<key>`, but it is expected to be in the form `0x<key>`
* remove the `ocr2on_starknet_` prefix from ocr2 onchain keyring and prepend `0x` instead
* adjust test case