### PR TITLE
Renamings to conform .sol interface

### DIFF
--- a/contracts/contracts/ocr2/Mock_Aggregator.cairo
+++ b/contracts/contracts/ocr2/Mock_Aggregator.cairo
@@ -5,71 +5,69 @@ from starkware.cairo.common.cairo_builtins import HashBuiltin
 from contracts.ocr2.interfaces.IAggregator import IAggregator, Round
 
 struct Transmission:
-    member answer: felt
-    member block_num: felt
-    member observation_timestamp: felt
-    member transmission_timestamp: felt
+    member answer : felt
+    member block_num : felt
+    member observation_timestamp : felt
+    member transmission_timestamp : felt
 end
 
 @storage_var
-func transmissions_(round_id: felt) -> (transmission: Transmission):
+func transmissions_(round_id : felt) -> (transmission : Transmission):
 end
 
 @storage_var
-func latest_aggregator_round_id_() -> (round_id: felt):
+func latest_aggregator_round_id_() -> (round_id : felt):
 end
 
 @storage_var
-func decimals_() -> (decimals: felt):
+func decimals_() -> (decimals : felt):
 end
 
 @storage_var
-func answer_() -> (answer: felt):
+func answer_() -> (answer : felt):
 end
 
 @event
 func new_transmission(
-    round_id: felt,
-    answer: felt,
-    transmitter: felt,
-    observation_timestamp: felt,
-    observers: felt,
-    observations_len: felt,
-    observations: felt*,
-    juels_per_fee_coin: felt,
-    config_digest: felt,
-    epoch_and_round: felt,
-    reimbursement: felt,
+    round_id : felt,
+    answer : felt,
+    transmitter : felt,
+    observation_timestamp : felt,
+    observers : felt,
+    observations_len : felt,
+    observations : felt*,
+    juels_per_fee_coin : felt,
+    config_digest : felt,
+    epoch_and_round : felt,
+    reimbursement : felt,
 ):
 end
 
-
 @constructor
-func constructor{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}(decimals: felt):
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    decimals : felt
+):
     decimals_.write(decimals)
     return ()
 end
 
 @external
-func set_latest_round_data{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}(answer: felt, block_num: felt, observation_timestamp: felt, transmission_timestamp: felt):
+func set_latest_round_data{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    answer : felt, block_num : felt, observation_timestamp : felt, transmission_timestamp : felt
+):
     alloc_locals
     let (prev_round_id) = latest_aggregator_round_id_.read()
     let round_id = prev_round_id + 1
     latest_aggregator_round_id_.write(round_id)
-    transmissions_.write(round_id, Transmission(
+    transmissions_.write(
+        round_id,
+        Transmission(
         answer=answer,
         block_num=block_num,
         observation_timestamp=observation_timestamp,
         transmission_timestamp=transmission_timestamp,
-    ))
+        ),
+    )
 
     let (observations : felt*) = alloc()
     assert observations[0] = 2
@@ -91,21 +89,19 @@ func set_latest_round_data{
 end
 
 @view
-func latest_round_data{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}() -> (round: Round):
+func latest_round_data{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    round : Round
+):
     alloc_locals
     let (latest_round_id) = latest_aggregator_round_id_.read()
-    let (transmission: Transmission) = transmissions_.read(latest_round_id)
+    let (transmission : Transmission) = transmissions_.read(latest_round_id)
 
     let round = Round(
         round_id=latest_round_id,
         answer=transmission.answer,
         block_num=transmission.block_num,
-        observation_timestamp=transmission.observation_timestamp,
-        transmission_timestamp=transmission.transmission_timestamp,
+        started_at=transmission.observation_timestamp,
+        updated_at=transmission.transmission_timestamp,
     )
     let (observations : felt*) = alloc()
     assert observations[0] = 2
@@ -127,11 +123,9 @@ func latest_round_data{
 end
 
 @view
-func decimals{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}() -> (decimals: felt):
+func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    decimals : felt
+):
     let (decimals) = decimals_.read()
     return (decimals)
 end

--- a/contracts/contracts/ocr2/SequencerUptimeFeed/library.cairo
+++ b/contracts/contracts/ocr2/SequencerUptimeFeed/library.cairo
@@ -17,7 +17,7 @@ from SimpleReadAccessController.library import simple_read_access_controller
 from ownable import Ownable_only_owner
 
 @event
-func RoundUpdated(status : felt, transmission_timestamp : felt):
+func RoundUpdated(status : felt, updated_at : felt):
 end
 
 @event
@@ -32,10 +32,6 @@ end
 
 @storage_var
 func s_l1_sender() -> (address : felt):
-end
-
-@storage_var
-func s_l2_cross_domain_messenger() -> (address : felt):
 end
 
 @storage_var
@@ -119,14 +115,12 @@ namespace sequencer_uptime_feed:
         assert_boolean(status)
 
         let (latest_round_id) = s_latest_round_id.read()
-        let (latest_observation_timestamp) = s_rounds.read(
-            latest_round_id, Round.observation_timestamp
-        )
+        let (latest_started_at) = s_rounds.read(latest_round_id, Round.started_at)
         let (local latest_status) = s_rounds.read(latest_round_id, Round.answer)
 
-        let (lt) = is_le(timestamp, latest_observation_timestamp - 1)  # timestamp < latest_observation_timestamp
+        let (lt) = is_le(timestamp, latest_started_at - 1)  # timestamp < latest_started_at
         if lt == TRUE:
-            UpdateIgnored.emit(latest_status, latest_observation_timestamp, status, timestamp)
+            UpdateIgnored.emit(latest_status, latest_started_at, status, timestamp)
             return ()
         end
 
@@ -188,12 +182,8 @@ func _set_round{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_pt
 ):
     s_rounds.write(id=round_id, field=Round.answer, value=value.answer)
     s_rounds.write(id=round_id, field=Round.block_num, value=value.block_num)
-    s_rounds.write(
-        id=round_id, field=Round.observation_timestamp, value=value.observation_timestamp
-    )
-    s_rounds.write(
-        id=round_id, field=Round.transmission_timestamp, value=value.transmission_timestamp
-    )
+    s_rounds.write(id=round_id, field=Round.started_at, value=value.started_at)
+    s_rounds.write(id=round_id, field=Round.updated_at, value=value.updated_at)
 
     return ()
 end
@@ -203,10 +193,10 @@ func _get_round{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_pt
 ) -> (round : Round):
     let (answer) = s_rounds.read(id=round_id, field=Round.answer)
     let (block_num) = s_rounds.read(id=round_id, field=Round.block_num)
-    let (observation_timestamp) = s_rounds.read(id=round_id, field=Round.observation_timestamp)
-    let (transmission_timestamp) = s_rounds.read(id=round_id, field=Round.transmission_timestamp)
+    let (started_at) = s_rounds.read(id=round_id, field=Round.started_at)
+    let (updated_at) = s_rounds.read(id=round_id, field=Round.updated_at)
 
-    return (Round(round_id, answer, block_num, observation_timestamp, transmission_timestamp))
+    return (Round(round_id, answer, block_num, started_at, updated_at))
 end
 
 func _set_l1_sender{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
@@ -229,14 +219,14 @@ func _record_round{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check
     s_latest_round_id.write(round_id)
 
     let (block_num) = get_block_number()
-    let (transmission_timestamp) = get_block_timestamp()
+    let (updated_at) = get_block_timestamp()
 
     let round = Round(
         round_id=round_id,
         answer=status,
         block_num=block_num,
-        observation_timestamp=timestamp,
-        transmission_timestamp=transmission_timestamp,
+        started_at=timestamp,
+        updated_at=updated_at,
     )
     _set_round(round_id, round)
 
@@ -250,9 +240,9 @@ end
 func _update_round{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
     round_id : felt, status : felt
 ):
-    let (transmission_timestamp) = get_block_timestamp()
-    s_rounds.write(round_id, Round.transmission_timestamp, transmission_timestamp)
+    let (updated_at) = get_block_timestamp()
+    s_rounds.write(round_id, Round.updated_at, updated_at)
 
-    RoundUpdated.emit(status, transmission_timestamp)
+    RoundUpdated.emit(status, updated_at)
     return ()
 end

--- a/contracts/contracts/ocr2/SequencerUptimeFeed/sequencer_uptime_feed.cairo
+++ b/contracts/contracts/ocr2/SequencerUptimeFeed/sequencer_uptime_feed.cairo
@@ -5,7 +5,7 @@ from starkware.starknet.common.syscalls import get_tx_info, get_block_timestamp
 
 from ocr2.interfaces.IAggregator import Round
 from ocr2.interfaces.IAccessController import IAccessController
-from ocr2.SequencerUptimeFeed.library import s_l2_cross_domain_messenger, sequencer_uptime_feed
+from ocr2.SequencerUptimeFeed.library import sequencer_uptime_feed
 from SimpleReadAccessController.library import simple_read_access_controller
 
 @constructor

--- a/contracts/contracts/ocr2/aggregator.cairo
+++ b/contracts/contracts/ocr2/aggregator.cairo
@@ -49,6 +49,8 @@ from contracts.ownable import (
     Ownable_accept_ownership
 )
 
+from ocr2.interfaces.IAggregator import Round
+
 # ---
 
 const MAX_ORACLES = 31
@@ -793,14 +795,6 @@ func decimals{
     return (decimals)
 end
 
-struct Round:
-    member round_id: felt
-    member answer: felt
-    member block_num: felt
-    member observation_timestamp: felt
-    member transmission_timestamp: felt
-end
-
 @view
 func round_data{
     syscall_ptr : felt*,
@@ -815,8 +809,8 @@ func round_data{
         round_id=round_id,
         answer=transmission.answer,
         block_num=transmission.block_num,
-        observation_timestamp=transmission.observation_timestamp,
-        transmission_timestamp=transmission.transmission_timestamp,
+        started_at=transmission.observation_timestamp,
+        updated_at=transmission.transmission_timestamp,
     )
     return (round)
 end
@@ -834,8 +828,8 @@ func latest_round_data{
         round_id=latest_round_id,
         answer=transmission.answer,
         block_num=transmission.block_num,
-        observation_timestamp=transmission.observation_timestamp,
-        transmission_timestamp=transmission.transmission_timestamp,
+        started_at=transmission.observation_timestamp,
+        updated_at=transmission.transmission_timestamp,
     )
     return (round)
 end
@@ -984,8 +978,6 @@ func billing_set(
 ):
 end
 
-# TODO: Why here and not in OffchainAggregatorBilling
-# Looks like they are merged now
 @external
 func set_billing{
     syscall_ptr : felt*,

--- a/contracts/contracts/ocr2/interfaces/IAggregator.cairo
+++ b/contracts/contracts/ocr2/interfaces/IAggregator.cairo
@@ -4,8 +4,8 @@ struct Round:
     member round_id : felt
     member answer : felt
     member block_num : felt
-    member observation_timestamp : felt
-    member transmission_timestamp : felt
+    member started_at : felt
+    member updated_at : felt
 end
 
 @event

--- a/contracts/contracts/ocr2/proxy.cairo
+++ b/contracts/contracts/ocr2/proxy.cairo
@@ -10,60 +10,50 @@ from contracts.ownable import (
     Ownable_only_owner,
     Ownable_get_owner,
     Ownable_transfer_ownership,
-    Ownable_accept_ownership
+    Ownable_accept_ownership,
 )
 
 struct Phase:
-    member id: felt
-    member aggregator: felt
+    member id : felt
+    member aggregator : felt
 end
 
 @storage_var
-func current_phase_() -> (phase: Phase):
+func current_phase_() -> (phase : Phase):
 end
 
 @storage_var
-func proposed_aggregator_() -> (address: felt):
+func proposed_aggregator_() -> (address : felt):
 end
 
 @storage_var
-func phases_(id: felt) -> (address: felt):
+func phases_(id : felt) -> (address : felt):
 end
 
 const SHIFT = 2 ** 128
 const MAX_ID = SHIFT - 1
 
-
 @event
-func aggregator_proposed(current: felt, proposed: felt):
+func aggregator_proposed(current : felt, proposed : felt):
 end
 
 @event
-func aggregator_confirmed(previous: felt, latest: felt):
+func aggregator_confirmed(previous : felt, latest : felt):
 end
 
 @constructor
-func constructor{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}(
-    owner: felt,
-    address: felt
+func constructor{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    owner : felt, address : felt
 ):
     Ownable_initializer(owner)
     set_aggregator(address)
     return ()
 end
 
-func set_aggregator{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}(
-    address: felt
+func set_aggregator{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    address : felt
 ):
-    let (current_phase: Phase) = current_phase_.read()
+    let (current_phase : Phase) = current_phase_.read()
     let id = current_phase.id + 1
     current_phase_.write(Phase(id=id, aggregator=address))
     phases_.write(id, address)
@@ -71,34 +61,26 @@ func set_aggregator{
 end
 
 @external
-func propose_aggregator{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}(
-    address: felt
+func propose_aggregator{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    address : felt
 ):
     Ownable_only_owner()
 
     proposed_aggregator_.write(address)
 
     # emit event
-    let (phase: Phase) = current_phase_.read()
+    let (phase : Phase) = current_phase_.read()
     aggregator_proposed.emit(current=phase.aggregator, proposed=address)
     return ()
 end
 
 @external
-func confirm_aggregator{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}(
-    address: felt
+func confirm_aggregator{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    address : felt
 ):
     Ownable_only_owner()
 
-    let (phase: Phase) = current_phase_.read()
+    let (phase : Phase) = current_phase_.read()
     let previous = phase.aggregator
 
     let (proposed_aggregator) = proposed_aggregator_.read()
@@ -112,122 +94,107 @@ func confirm_aggregator{
 end
 
 @view
-func latest_round_data{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}() -> (round: Round):
+func latest_round_data{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    round : Round
+):
     # alloc_locals
-    let (phase: Phase) = current_phase_.read()
-    let (round: Round) = IAggregator.latest_round_data(contract_address=phase.aggregator)
+    let (phase : Phase) = current_phase_.read()
+    let (round : Round) = IAggregator.latest_round_data(contract_address=phase.aggregator)
 
     # Add phase_id to the high bits of round_id
     let round_id = round.round_id + (phase.id * SHIFT)
-    return (Round(
+    return (
+        Round(
         round_id=round_id,
         answer=round.answer,
         block_num=round.block_num,
-        observation_timestamp=round.observation_timestamp,
-        transmission_timestamp=round.transmission_timestamp,
-    ))
+        started_at=round.started_at,
+        updated_at=round.updated_at,
+        ),
+    )
 end
 
 @view
-func round_data{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}(round_id: felt) -> (round: Round):
+func round_data{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    round_id : felt
+) -> (round : Round):
     let (phase_id, round_id) = split_felt(round_id)
     let (address) = phases_.read(phase_id)
     assert_not_zero(address)
 
-    let (round: Round) = IAggregator.round_data(contract_address=address, round_id=round_id)
+    let (round : Round) = IAggregator.round_data(contract_address=address, round_id=round_id)
     # Add phase_id to the high bits of round_id
     let round_id = round.round_id + (phase_id * SHIFT)
-    return (Round(
+    return (
+        Round(
         round_id=round_id,
         answer=round.answer,
         block_num=round.block_num,
-        observation_timestamp=round.observation_timestamp,
-        transmission_timestamp=round.transmission_timestamp,
-    ))
+        started_at=round.started_at,
+        updated_at=round.updated_at,
+        ),
+    )
 end
 
 # These read from the proposed aggregator as a way to test the aggregator before making setting it live.
 
 @view
-func proposed_latest_round_data{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}() -> (round: Round):
+func proposed_latest_round_data{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    ) -> (round : Round):
     # alloc_locals
     let (aggregator) = proposed_aggregator_.read()
-    let (round: Round) = IAggregator.latest_round_data(contract_address=aggregator)
+    let (round : Round) = IAggregator.latest_round_data(contract_address=aggregator)
     return (round)
 end
 
 @view
-func proposed_round_data{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}(round_id: felt) -> (round: Round):
+func proposed_round_data{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}(
+    round_id : felt
+) -> (round : Round):
     let (aggregator) = proposed_aggregator_.read()
-    let (round: Round) = IAggregator.round_data(contract_address=aggregator, round_id=round_id)
+    let (round : Round) = IAggregator.round_data(contract_address=aggregator, round_id=round_id)
     return (round)
 end
 
 @view
-func aggregator{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}() -> (aggregator: felt):
-    let (phase: Phase) = current_phase_.read()
+func aggregator{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    aggregator : felt
+):
+    let (phase : Phase) = current_phase_.read()
     return (phase.aggregator)
 end
 
 @view
-func phase_id{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}() -> (phase_id: felt):
-    let (phase: Phase) = current_phase_.read()
+func phase_id{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    phase_id : felt
+):
+    let (phase : Phase) = current_phase_.read()
     return (phase.id)
 end
 
 @view
-func description{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}() -> (description: felt):
-    let (phase: Phase) = current_phase_.read()
+func description{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    description : felt
+):
+    let (phase : Phase) = current_phase_.read()
     let (description) = IAggregator.description(contract_address=phase.aggregator)
     return (description)
 end
 
 @view
-func decimals{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}() -> (decimals: felt):
-    let (phase: Phase) = current_phase_.read()
+func decimals{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    decimals : felt
+):
+    let (phase : Phase) = current_phase_.read()
     let (decimals) = IAggregator.decimals(contract_address=phase.aggregator)
     return (decimals)
 end
 
 @view
-func type_and_version{
-    syscall_ptr : felt*,
-    pedersen_ptr : HashBuiltin*,
-    range_check_ptr,
-}() -> (meta: felt):
-    let (phase: Phase) = current_phase_.read()
+func type_and_version{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}() -> (
+    meta : felt
+):
+    let (phase : Phase) = current_phase_.read()
     let (meta) = IAggregator.type_and_version(contract_address=phase.aggregator)
     return (meta)
 end

--- a/contracts/test/ocr2/proxy-test.ts
+++ b/contracts/test/ocr2/proxy-test.ts
@@ -60,8 +60,8 @@ describe('proxy.cairo', function () {
     // TODO: split_felt the round_id and check phase=1 round=1
     assert.equal(round.answer, '10')
     assert.equal(round.block_num, '1')
-    assert.equal(round.observation_timestamp, '9')
-    assert.equal(round.transmission_timestamp, '8')
+    assert.equal(round.started_at, '9')
+    assert.equal(round.updated_at, '8')
 
     // insert a second ocr2 aggregator
     let new_aggregator = await aggregatorContractFactory.deploy({ decimals: 8 })

--- a/examples/contracts/aggregator-consumer/test/mock/mock-test.ts
+++ b/examples/contracts/aggregator-consumer/test/mock/mock-test.ts
@@ -37,8 +37,8 @@ describe('ContractTestsMock', function () {
       console.log(round.answer)
       assert.equal(round.answer, 12)
       assert.equal(round.block_num, 1)
-      assert.equal(round.observation_timestamp, 14325)
-      assert.equal(round.transmission_timestamp, 87654)
+      assert.equal(round.started_at, 14325)
+      assert.equal(round.updated_at, 87654)
     }
   })
   it('should set and read latest round data successfully for the second time', async () => {
@@ -53,8 +53,8 @@ describe('ContractTestsMock', function () {
       const { round: round } = await ConsumerContract.call('readLatestRound', {})
       assert.equal(round.answer, 19)
       assert.equal(round.block_num, 2)
-      assert.equal(round.observation_timestamp, 14345)
-      assert.equal(round.transmission_timestamp, 62543)
+      assert.equal(round.started_at, 14345)
+      assert.equal(round.updated_at, 62543)
     }
   })
   it('should set and read latest round data successfully for the third time', async () => {


### PR DESCRIPTION
Change observation_timestamp -> started_at, transmission_timestamp -> updated_at to conform to conform `AggregatorV3Interface` namings