### PR TITLE
Remove assert_not_zero which check if caller address is zero

### DIFF
--- a/contracts/src/chainlink/cairo/access/ownable.cairo
+++ b/contracts/src/chainlink/cairo/access/ownable.cairo
@@ -46,6 +46,7 @@ namespace Ownable:
     func assert_only_owner{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_check_ptr}():
         let (owner) = Ownable_owner.read()
         let (caller) = get_caller_address()
+        # caller is the zero address should not be possible anymore with introduction of fees
         with_attr error_message("Ownable: Caller is the zero address"):
             assert_not_zero(caller)
         end

--- a/contracts/src/chainlink/cairo/ocr2/aggregator.cairo
+++ b/contracts/src/chainlink/cairo/ocr2/aggregator.cairo
@@ -1181,10 +1181,6 @@ func accept_payeeship{syscall_ptr : felt*, pedersen_ptr : HashBuiltin*, range_ch
 ):
     let (proposed) = Aggregator_proposed_payees.read(transmitter)
     let (caller) = get_caller_address()
-    # caller cannot be zero address to avoid overwriting owner when proposed_owner is not set
-    with_attr error_message("caller is the zero address"):
-        assert_not_zero(caller)
-    end
     with_attr error_message("only proposed payee can accept"):
         assert caller = proposed
     end

--- a/contracts/test/access/behavior/ownable.ts
+++ b/contracts/test/access/behavior/ownable.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai'
+import { starknet } from 'hardhat'
 import { StarknetContract, Account } from 'hardhat/types/runtime'
 import { hexPadStart } from '../../utils'
 
@@ -90,6 +91,19 @@ export const shouldBehaveLikeOwnableContract = (beforeFn: BeforeFn) => {
       // owner is now alice
       await expectOwner(t.ownable, alice)
       await expectProposedOwner(t.ownable, hexPadStart(0, ADDRESS_LEN)) // 0x0
+    })
+
+    it(`should fail with account without fees`, async () => {
+      const accountNoFees = await starknet.deployAccount('OpenZeppelin')
+
+      await t.alice.invoke(t.ownable, 'transfer_ownership', {
+        new_owner: accountNoFees.address,
+      })
+
+      try {
+        await accountNoFees.invoke(t.ownable, 'accept_ownership', { maxFee: 1e18 })
+        expect.fail()
+      } catch (err: any) {}
     })
   })
 }


### PR DESCRIPTION
Since invoke functions will need to be call by account with funds they can't be zero address.