### PR TITLE
Increased remote runner memory and adjusted TTL value

### DIFF
--- a/integration-tests/common/gauntlet_common.go
+++ b/integration-tests/common/gauntlet_common.go
@@ -38,7 +38,7 @@ func (t *Test) fundNodes() error {
 		for _, key := range nAccounts {
 			// We are not deploying in parallel here due to testnet limitations (429 too many requests)
 			log.Debug().Msg(fmt.Sprintf("Funding node with address: %s", key))
-			_, err = t.Sg.TransferToken(ethAddressGoerli, key, "10000000000000000") // Transferring 0.1 ETH to each node
+			_, err = t.Sg.TransferToken(ethAddressGoerli, key, "1000000000000000000") // Transferring 1 ETH to each node
 			if err != nil {
 				return err
 			}

--- a/integration-tests/soak/soak_runner_test.go
+++ b/integration-tests/soak/soak_runner_test.go
@@ -55,7 +55,7 @@ func soakTestHelper(
 	envValues := map[string]interface{}{
 		"test_log_level": "debug",
 		"INSIDE_K8":      true,
-		"TTL":            c.TTL,
+		"TTL":            c.TTL.String(),
 		"NODE_COUNT":     c.NodeCount,
 		"L2_RPC_URL":     c.L2RPCUrl,
 		"PRIVATE_KEY":    c.PrivateKey,
@@ -79,11 +79,11 @@ func soakTestHelper(
 		"resources": map[string]interface{}{
 			"requests": map[string]interface{}{
 				"cpu":    "2000m",
-				"memory": "1048Mi",
+				"memory": "2048Mi",
 			},
 			"limits": map[string]interface{}{
 				"cpu":    "2000m",
-				"memory": "1048Mi",
+				"memory": "2048Mi",
 			},
 		},
 	}


### PR DESCRIPTION
- Increased funding to 1 ETH
- Fixed bug with TTL parse in remote runner
- Increased remote runner memory due to yarn exiting