### PR TITLE
Run gauntlet binary release and relayer code release on workflow_dispatch

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -34,8 +34,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-      # Dispatch Relayer build & release
-      - name: Build and release relayer
+      # Dispatch Relayer release
+      - name: Release relayer
         run: gh workflow run release/starknet-relayer
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -36,11 +36,11 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       # Dispatch Relayer release
       - name: Release relayer
-        run: gh workflow run .github/workflows/release/starknet-relayer
+        run: gh workflow run .github/workflows/release/starknet-relayer.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Dispatch Gauntlet CLI build & release
       - name: Build and release Gauntlet CLI
-        run: gh workflow run .github/workflows/release/starknet-gauntlet-cli
+        run: gh workflow run .github/workflows/release/starknet-gauntlet-cli.yml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -36,11 +36,11 @@ jobs:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
       # Dispatch Relayer release
       - name: Release relayer
-        run: gh workflow run release/starknet-relayer
+        run: gh workflow run .github/workflows/release/starknet-relayer
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Dispatch Gauntlet CLI build & release
       - name: Build and release Gauntlet CLI
-        run: gh workflow run release/starknet-gauntlet-cli
+        run: gh workflow run .github/workflows/release/starknet-gauntlet-cli
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
-          token: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
       # Install nix
       - name: Install Nix
         uses: cachix/install-nix-action@d64e0553100205688c0fb2fa16edb0fc8663c590 # v17
@@ -32,5 +32,11 @@ jobs:
         with:
           publish: nix develop -c yarn release
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # Dispatch Relayer build & release
+      - name: Build and release relayer
+        run: gh workflow run release/starknet-relayer
+      # Dispatch Gauntlet CLI build & release
+      - name: Build and release Gauntlet CLI
+        run: gh workflow run release/starknet-gauntlet-cli

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -37,6 +37,10 @@ jobs:
       # Dispatch Relayer build & release
       - name: Build and release relayer
         run: gh workflow run release/starknet-relayer
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Dispatch Gauntlet CLI build & release
       - name: Build and release Gauntlet CLI
         run: gh workflow run release/starknet-gauntlet-cli
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release/starknet-gauntlet-cli.yml
+++ b/.github/workflows/release/starknet-gauntlet-cli.yml
@@ -1,9 +1,7 @@
 name: Starknet Gauntlet CLI Release
 
 on:
-  push:
-    tags:
-      - "@chainlink/starknet-gauntlet-cli@[0-9]+.[0-9]+.[0-9]"
+  workflow_dispatch:
 
 jobs:
   starknet-gauntlet-cli-release:

--- a/.github/workflows/release/starknet-relayer.yml
+++ b/.github/workflows/release/starknet-relayer.yml
@@ -16,7 +16,7 @@ jobs:
         run: echo "STARKNET_RELAYER=$(npm info @chainlink/starknet-relayer version)" >> $GITHUB_ENV
       # Check if release tag exists
       - name: Check release tag
-        uses: mukunku/tag-exists-action@v1.0.0
+        uses: mukunku/tag-exists-action@5dfe2bf779fe5259360bb10b2041676713dcc8a3 # v1.1.0
         id: checkTag
         with:
           tag: relayer/v${{ env.STARKNET_RELAYER }}

--- a/.github/workflows/release/starknet-relayer.yml
+++ b/.github/workflows/release/starknet-relayer.yml
@@ -25,7 +25,7 @@ jobs:
       # Release code under vX.X.X
       - name: Release Code
         if: steps.checkTag.outputs.exists == 'false'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@de2c0eb89ae2a093876385947365aca7b0e5f844 # v1
         with:
           tag_name: relayer/v${{ env.STARKNET_RELAYER }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release/starknet-relayer.yml
+++ b/.github/workflows/release/starknet-relayer.yml
@@ -14,8 +14,17 @@ jobs:
       # Store starknet version
       - name: Set Env Variables
         run: echo "STARKNET_RELAYER=$(npm info @chainlink/starknet-relayer version)" >> $GITHUB_ENV
+      # Check if release tag exists
+      - name: Check release tag
+        uses: mukunku/tag-exists-action@v1.0.0
+        id: checkTag
+        with:
+          tag: relayer/v${{ env.STARKNET_RELAYER }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       # Release code under vX.X.X
       - name: Release Code
+        if: steps.checkTag.outputs.exists == 'false'
         uses: softprops/action-gh-release@v1
         with:
           tag_name: relayer/v${{ env.STARKNET_RELAYER }}

--- a/.github/workflows/release/starknet-relayer.yml
+++ b/.github/workflows/release/starknet-relayer.yml
@@ -1,9 +1,7 @@
 name: Starknet Relayer Release
 
 on:
-  push:
-    tags:
-      - "@chainlink/starknet-relayer@[0-9]+.[0-9]+.[0-9]"
+  workflow_dispatch:
 
 jobs:
   starknet-relayer-release:


### PR DESCRIPTION
Currently, the changesets action creates tags that trigger the gauntlet and relayer release workflows. However, since `secrets.GITHUB_TOKEN` can only trigger other workflows by making explicit dispatch calls, we would need to configure a custom personal access token or a deployment token for the release workflows to run on tag creation.

This PR makes the changesets action simply dispatch the release workflows, removing the requirement for a custom token.

NOTE: We still need to configure `secrets.NPM_TOKEN` if we have not already.