### PR TITLE
Revert "Stub NewMercuryProvider"

### DIFF
--- a/relayer/pkg/chainlink/relay.go
+++ b/relayer/pkg/chainlink/relay.go
@@ -104,7 +104,3 @@ func (r *relayer) NewMedianProvider(rargs relaytypes.RelayArgs, pargs relaytypes
 
 	return medianProvider, nil
 }
-
-func (r *relayer) NewMercuryProvider(rargs relaytypes.RelayArgs, pargs relaytypes.PluginArgs) (relaytypes.MercuryProvider, error) {
-	return nil, errors.New("mercury is not supported for starknet")
-}


### PR DESCRIPTION
Breaks CI, doesn't compile without chainlink-relay changes