### PR TITLE
only bind to localhost for k3d registry and API server

### DIFF
--- a/ops/localenv/main.go
+++ b/ops/localenv/main.go
@@ -27,8 +27,8 @@ func main() {
 	switch strings.ToLower(os.Args[1]) {
 	// create k8s cluster + resources
 	case "create":
-		run("create registry", "k3d", "registry", "create", "registry.localhost", "--port", "12345")
-		run("create k8s cluster", "k3d", "cluster", "create", "local", "--registry-use", "k3d-registry.localhost:12345")
+		run("create registry", "k3d", "registry", "create", "registry.localhost", "--port", "127.0.0.1:12345")
+		run("create k8s cluster", "k3d", "cluster", "create", "local", "--api-port", "127.0.0.1:12346", "--registry-use", "k3d-registry.localhost:12345")
 		run("switch k8s context", "kubectl", "config", "use-context", "k3d-local")
 	// build and upload image to local registry
 	case "build":


### PR DESCRIPTION
currently the k3d registry and API server listens on all interfaces which would allow external connections, only listen locally