### PR TITLE
BCI-1259: Add upgradeability

### DIFF
--- a/contracts/src/emergency/sequencer_uptime_feed.cairo
+++ b/contracts/src/emergency/sequencer_uptime_feed.cairo
@@ -145,9 +145,11 @@ mod SequencerUptimeFeed {
     /// Upgradeable
     ///
 
+    // todo add test calling with non owner once calvin's changes are merged
     #[external]
     fn upgrade(impl_hash: ClassHash) {
-        Upgradeable::upgrade_only_owner(impl_hash)
+        Ownable::assert_only_owner();
+        Upgradeable::_upgrade(impl_hash)
     }
 
     ///

--- a/contracts/src/emergency/sequencer_uptime_feed.cairo
+++ b/contracts/src/emergency/sequencer_uptime_feed.cairo
@@ -7,6 +7,8 @@ mod SequencerUptimeFeed {
     use starknet::storage_read_syscall;
     use starknet::storage_write_syscall;
     use starknet::storage_address_from_base_and_offset;
+    use starknet::class_hash::ClassHash;
+    use starknet::class_hash::ClassHashZeroable;
 
     use box::BoxTrait;
     use traits::Into;
@@ -21,6 +23,7 @@ mod SequencerUptimeFeed {
     use chainlink::ocr2::aggregator::IAggregator;
     use chainlink::ocr2::aggregator::Aggregator::Transmission;
     use chainlink::ocr2::aggregator::Aggregator::TransmissionStorageAccess;
+    use chainlink::libraries::upgradeable::Upgradeable;
 
     const ETH_ADDRESS_BOUND: felt252 = 0x10000000000000000000000000000000000000000; // 2**160
 
@@ -139,6 +142,14 @@ mod SequencerUptimeFeed {
         _l1_sender::read()
     }
 
+    ///
+    /// Upgradeable
+    ///
+
+    #[external]
+    fn upgrade(impl_hash: ClassHash) {
+        Upgradeable::upgrade(impl_hash)
+    }
 
     ///
     /// Aggregator

--- a/contracts/src/emergency/sequencer_uptime_feed.cairo
+++ b/contracts/src/emergency/sequencer_uptime_feed.cairo
@@ -8,7 +8,6 @@ mod SequencerUptimeFeed {
     use starknet::storage_write_syscall;
     use starknet::storage_address_from_base_and_offset;
     use starknet::class_hash::ClassHash;
-    use starknet::class_hash::ClassHashZeroable;
 
     use box::BoxTrait;
     use traits::Into;
@@ -148,7 +147,7 @@ mod SequencerUptimeFeed {
 
     #[external]
     fn upgrade(impl_hash: ClassHash) {
-        Upgradeable::upgrade(impl_hash)
+        Upgradeable::upgrade_only_owner(impl_hash)
     }
 
     ///

--- a/contracts/src/emergency/sequencer_uptime_feed.cairo
+++ b/contracts/src/emergency/sequencer_uptime_feed.cairo
@@ -147,9 +147,9 @@ mod SequencerUptimeFeed {
 
     // todo add test calling with non owner once calvin's changes are merged
     #[external]
-    fn upgrade(new_class_hash: ClassHash) {
+    fn upgrade(new_impl: ClassHash) {
         Ownable::assert_only_owner();
-        Upgradeable::upgrade(new_class_hash)
+        Upgradeable::upgrade(new_impl)
     }
 
     ///

--- a/contracts/src/emergency/sequencer_uptime_feed.cairo
+++ b/contracts/src/emergency/sequencer_uptime_feed.cairo
@@ -147,9 +147,9 @@ mod SequencerUptimeFeed {
 
     // todo add test calling with non owner once calvin's changes are merged
     #[external]
-    fn upgrade(impl_hash: ClassHash) {
+    fn upgrade(new_class_hash: ClassHash) {
         Ownable::assert_only_owner();
-        Upgradeable::_upgrade(impl_hash)
+        Upgradeable::upgrade(new_class_hash)
     }
 
     ///

--- a/contracts/src/libraries.cairo
+++ b/contracts/src/libraries.cairo
@@ -3,3 +3,4 @@ mod access_controller;
 mod simple_write_access_controller;
 mod simple_read_access_controller;
 mod token;
+mod upgradeable;

--- a/contracts/src/libraries/simple_read_access_controller.cairo
+++ b/contracts/src/libraries/simple_read_access_controller.cairo
@@ -1,9 +1,14 @@
 #[contract]
-mod SimpleReadAccessController {
-    use starknet::ContractAddress;
+mod SimpleReadAccessController {    
     use zeroable::Zeroable;
+
+    use starknet::ContractAddress;
+    use starknet::class_hash::ClassHash;
+    
+    use chainlink::libraries::ownable::Ownable;
     use chainlink::libraries::access_controller::AccessController;
     use chainlink::libraries::simple_write_access_controller::SimpleWriteAccessController;
+    use chainlink::libraries::upgradeable::Upgradeable;
 
     #[constructor]
     fn constructor(owner_address: ContractAddress) {
@@ -40,7 +45,16 @@ mod SimpleReadAccessController {
     fn check_access(user: ContractAddress) {
         SimpleReadAccessController::check_access(user)
     }
-    
+
+    ///
+    /// Upgradeable
+    ///
+
+    #[external]
+    fn upgrade(new_impl: ClassHash) {
+        Ownable::assert_only_owner();
+        Upgradeable::upgrade(new_impl)
+    }
 
     ///
     /// Internals

--- a/contracts/src/libraries/simple_read_access_controller.cairo
+++ b/contracts/src/libraries/simple_read_access_controller.cairo
@@ -41,6 +41,7 @@ mod SimpleReadAccessController {
     fn check_access(user: ContractAddress) {
         SimpleReadAccessController::check_access(user)
     }
+    
 
     ///
     /// Internals

--- a/contracts/src/libraries/simple_write_access_controller.cairo
+++ b/contracts/src/libraries/simple_write_access_controller.cairo
@@ -1,8 +1,11 @@
 #[contract]
 mod SimpleWriteAccessController {
     use starknet::ContractAddress;
+    use starknet::class_hash::ClassHash;
+
     use chainlink::libraries::access_controller::AccessController;
     use chainlink::libraries::ownable::Ownable;
+    use chainlink::libraries::upgradeable::Upgradeable;
 
     struct Storage {
         _check_enabled: bool,
@@ -95,6 +98,15 @@ mod SimpleWriteAccessController {
             _check_enabled::write(false);
             CheckAccessDisabled();
         }
+    }
+
+    ///
+    /// Upgradeable
+    ///
+    #[external]
+    fn upgrade(new_impl: ClassHash) {
+        Ownable::assert_only_owner();
+        Upgradeable::upgrade(new_impl)
     }
 
     ///

--- a/contracts/src/libraries/upgradeable.cairo
+++ b/contracts/src/libraries/upgradeable.cairo
@@ -6,20 +6,13 @@ mod Upgradeable {
     use starknet::class_hash::ClassHash;
     use starknet::class_hash::ClassHashZeroable;
 
-    use chainlink::libraries::ownable::Ownable;
-
     #[event]
     fn Upgraded(implementation: ClassHash) {}
-
-    fn upgrade_only_owner(impl_hash: ClassHash) {
-        Ownable::assert_only_owner();
-        upgrade(impl_hash);
-    }
 
     // this method assumes replace_class_syscall has a very low possibility of being deprecated
     // but if it does, we will either have upgraded the contract to be non-upgradeable by then
     // because the starknet ecosystem has stabilized or we will be able to upgrade the contract to the proxy pattern
-    fn upgrade(impl_hash: ClassHash) {
+    fn _upgrade(impl_hash: ClassHash) {
         assert(!impl_hash.is_zero(), 'Class hash cannot be zero');
         replace_class_syscall(impl_hash);
         Upgraded(impl_hash);

--- a/contracts/src/libraries/upgradeable.cairo
+++ b/contracts/src/libraries/upgradeable.cairo
@@ -16,6 +16,9 @@ mod Upgradeable {
         upgrade(impl_hash);
     }
 
+    // this method assumes replace_class_syscall has a very low possibility of being deprecated
+    // but if it does, we will either have upgraded the contract to be non-upgradeable by then
+    // because the starknet ecosystem has stabilized or we will be able to upgrade the contract to the proxy pattern
     fn upgrade(impl_hash: ClassHash) {
         assert(!impl_hash.is_zero(), 'Class hash cannot be zero');
         replace_class_syscall(impl_hash);

--- a/contracts/src/libraries/upgradeable.cairo
+++ b/contracts/src/libraries/upgradeable.cairo
@@ -2,19 +2,21 @@
 mod Upgradeable {
     use zeroable::Zeroable;
 
+    use starknet::SyscallResult;
+    use starknet::SyscallResultTrait;
     use starknet::syscalls::replace_class_syscall;
     use starknet::class_hash::ClassHash;
     use starknet::class_hash::ClassHashZeroable;
 
     #[event]
-    fn Upgraded(implementation: ClassHash) {}
+    fn Upgraded(new_class_hash: ClassHash) {}
 
     // this method assumes replace_class_syscall has a very low possibility of being deprecated
     // but if it does, we will either have upgraded the contract to be non-upgradeable by then
     // because the starknet ecosystem has stabilized or we will be able to upgrade the contract to the proxy pattern
-    fn _upgrade(impl_hash: ClassHash) {
-        assert(!impl_hash.is_zero(), 'Class hash cannot be zero');
-        replace_class_syscall(impl_hash);
-        Upgraded(impl_hash);
+    fn upgrade(new_class_hash: ClassHash) {
+        assert(!new_class_hash.is_zero(), 'Class hash cannot be zero');
+        replace_class_syscall(new_class_hash).unwrap_syscall();
+        Upgraded(new_class_hash);
     }
 }

--- a/contracts/src/libraries/upgradeable.cairo
+++ b/contracts/src/libraries/upgradeable.cairo
@@ -9,14 +9,15 @@ mod Upgradeable {
     use starknet::class_hash::ClassHashZeroable;
 
     #[event]
-    fn Upgraded(new_class_hash: ClassHash) {}
+    fn Upgraded(new_impl: ClassHash) {}
 
     // this method assumes replace_class_syscall has a very low possibility of being deprecated
     // but if it does, we will either have upgraded the contract to be non-upgradeable by then
     // because the starknet ecosystem has stabilized or we will be able to upgrade the contract to the proxy pattern
-    fn upgrade(new_class_hash: ClassHash) {
-        assert(!new_class_hash.is_zero(), 'Class hash cannot be zero');
-        replace_class_syscall(new_class_hash).unwrap_syscall();
-        Upgraded(new_class_hash);
+    #[internal]
+    fn upgrade(new_impl: ClassHash) {
+        assert(!new_impl.is_zero(), 'Class hash cannot be zero');
+        replace_class_syscall(new_impl).unwrap_syscall();
+        Upgraded(new_impl);
     }
 }

--- a/contracts/src/libraries/upgradeable.cairo
+++ b/contracts/src/libraries/upgradeable.cairo
@@ -1,0 +1,20 @@
+
+mod Upgradeable {
+    use zeroable::Zeroable;
+
+    use starknet::syscalls::replace_class_syscall;
+    use starknet::class_hash::ClassHash;
+    use starknet::class_hash::ClassHashZeroable;
+
+    use chainlink::libraries::ownable::Ownable;
+
+    #[event]
+    fn Upgraded(implementation: ClassHash) {}
+
+    fn upgrade(impl_hash: ClassHash) {
+        Ownable::assert_only_owner();
+        assert(!impl_hash.is_zero(), 'Class hash cannot be zero');
+        replace_class_syscall(impl_hash);
+        Upgraded(impl_hash);
+    }
+}

--- a/contracts/src/libraries/upgradeable.cairo
+++ b/contracts/src/libraries/upgradeable.cairo
@@ -11,8 +11,12 @@ mod Upgradeable {
     #[event]
     fn Upgraded(implementation: ClassHash) {}
 
-    fn upgrade(impl_hash: ClassHash) {
+    fn upgrade_only_owner(impl_hash: ClassHash) {
         Ownable::assert_only_owner();
+        upgrade(impl_hash);
+    }
+
+    fn upgrade(impl_hash: ClassHash) {
         assert(!impl_hash.is_zero(), 'Class hash cannot be zero');
         replace_class_syscall(impl_hash);
         Upgraded(impl_hash);

--- a/contracts/src/multisig.cairo
+++ b/contracts/src/multisig.cairo
@@ -224,9 +224,9 @@ mod Multisig {
     /// Externals
 
     #[external]
-    fn upgrade(new_class_hash: ClassHash) {
+    fn upgrade(new_impl: ClassHash) {
         _require_multisig();
-        Upgradeable::upgrade(new_class_hash)
+        Upgradeable::upgrade(new_impl)
     }
 
     #[external]

--- a/contracts/src/multisig.cairo
+++ b/contracts/src/multisig.cairo
@@ -37,9 +37,15 @@ impl TPartialEq: PartialEq::<T>,
 
 #[contract]
 mod Multisig {
+    use super::assert_unique_values;
+
+    use traits::Into;
+    use traits::TryInto;
+    use zeroable::Zeroable;
     use array::ArrayTrait;
     use array::ArrayTCloneImpl;
     use option::OptionTrait;
+    
     use starknet::ContractAddress;
     use starknet::ContractAddressIntoFelt252;
     use starknet::Felt252TryIntoContractAddress;
@@ -52,11 +58,9 @@ mod Multisig {
     use starknet::storage_address_from_base_and_offset;
     use starknet::storage_read_syscall;
     use starknet::storage_write_syscall;
-    use traits::Into;
-    use traits::TryInto;
-    use zeroable::Zeroable;
+    use starknet::class_hash::ClassHash;
 
-    use super::assert_unique_values;
+    use chainlink::libraries::upgradeable::Upgradeable;
 
     #[event]
     fn TransactionSubmitted(signer: ContractAddress, nonce: u128, to: ContractAddress) {}
@@ -218,6 +222,12 @@ mod Multisig {
     }
 
     /// Externals
+
+    #[external]
+    fn upgrade(impl_hash: ClassHash) {
+        _require_multisig();
+        Upgradeable::upgrade(impl_hash)
+    }
 
     #[external]
     fn submit_transaction(

--- a/contracts/src/multisig.cairo
+++ b/contracts/src/multisig.cairo
@@ -224,9 +224,9 @@ mod Multisig {
     /// Externals
 
     #[external]
-    fn upgrade(impl_hash: ClassHash) {
+    fn upgrade(new_class_hash: ClassHash) {
         _require_multisig();
-        Upgradeable::_upgrade(impl_hash)
+        Upgradeable::upgrade(new_class_hash)
     }
 
     #[external]

--- a/contracts/src/multisig.cairo
+++ b/contracts/src/multisig.cairo
@@ -226,7 +226,7 @@ mod Multisig {
     #[external]
     fn upgrade(impl_hash: ClassHash) {
         _require_multisig();
-        Upgradeable::upgrade(impl_hash)
+        Upgradeable::_upgrade(impl_hash)
     }
 
     #[external]

--- a/contracts/src/ocr2/aggregator.cairo
+++ b/contracts/src/ocr2/aggregator.cairo
@@ -90,7 +90,6 @@ mod Aggregator {
     use starknet::storage_write_syscall;
     use starknet::storage_address_from_base_and_offset;
     use starknet::class_hash::ClassHash;
-    use starknet::class_hash::ClassHashZeroable;
 
     use chainlink::libraries::ownable::Ownable;
     use chainlink::libraries::simple_read_access_controller::SimpleReadAccessController;
@@ -302,7 +301,7 @@ mod Aggregator {
 
     #[external]
     fn upgrade(impl_hash: ClassHash) {
-        Upgradeable::upgrade(impl_hash)
+        Upgradeable::upgrade_only_owner(impl_hash)
     }
 
     // --- Ownership ---

--- a/contracts/src/ocr2/aggregator.cairo
+++ b/contracts/src/ocr2/aggregator.cairo
@@ -64,36 +64,39 @@ impl TCopy: Copy::<T>> of LegacyHash::<Span<T>> {
 mod Aggregator {
     use super::IAggregator;
     use super::Round;
-    use starknet::get_caller_address;
-    use starknet::contract_address_const;
-    use starknet::ContractAddressZeroable;
+    use super::SpanLegacyHash;
+    use super::pow;
+
+    use array::ArrayTrait;
+    use array::SpanTrait;
+    use box::BoxTrait;
+    use hash::LegacyHash;
     use integer::U128IntoFelt252;
     use integer::u128s_from_felt252;
     use integer::U128sFromFelt252Result;
     use zeroable::Zeroable;
+    use traits::Into;
+    use traits::TryInto;
+    use option::OptionTrait;
 
     use starknet::ContractAddress;
-
+    use starknet::get_caller_address;
+    use starknet::contract_address_const;
+    use starknet::ContractAddressZeroable;
     use starknet::StorageAccess;
     use starknet::StorageBaseAddress;
     use starknet::SyscallResult;
     use starknet::storage_read_syscall;
     use starknet::storage_write_syscall;
     use starknet::storage_address_from_base_and_offset;
-    use traits::Into;
-    use traits::TryInto;
-    use option::OptionTrait;
+    use starknet::class_hash::ClassHash;
+    use starknet::class_hash::ClassHashZeroable;
 
-    use array::ArrayTrait;
-    use array::SpanTrait;
-    use box::BoxTrait;
-    use hash::LegacyHash;
-    use super::SpanLegacyHash;
-    use super::pow;
     use chainlink::libraries::ownable::Ownable;
     use chainlink::libraries::simple_read_access_controller::SimpleReadAccessController;
     use chainlink::libraries::simple_write_access_controller::SimpleWriteAccessController;
     use chainlink::utils::split_felt;
+    use chainlink::libraries::upgradeable::Upgradeable;
 
     // NOTE: remove duplication once we can directly use the trait
     #[abi]
@@ -293,6 +296,13 @@ mod Aggregator {
 
         _decimals::write(decimals);
         _description::write(description);
+    }
+
+    // --- Upgradeable ---
+
+    #[external]
+    fn upgrade(impl_hash: ClassHash) {
+        Upgradeable::upgrade(impl_hash)
     }
 
     // --- Ownership ---

--- a/contracts/src/ocr2/aggregator.cairo
+++ b/contracts/src/ocr2/aggregator.cairo
@@ -297,9 +297,9 @@ mod Aggregator {
     // --- Upgradeable ---
 
     #[external]
-    fn upgrade(impl_hash: ClassHash) {
+    fn upgrade(new_class_hash: ClassHash) {
         Ownable::assert_only_owner();
-        Upgradeable::_upgrade(impl_hash)
+        Upgradeable::upgrade(new_class_hash)
     }
 
     // --- Ownership ---

--- a/contracts/src/ocr2/aggregator.cairo
+++ b/contracts/src/ocr2/aggregator.cairo
@@ -298,7 +298,8 @@ mod Aggregator {
 
     #[external]
     fn upgrade(impl_hash: ClassHash) {
-        Upgradeable::upgrade_only_owner(impl_hash)
+        Ownable::assert_only_owner();
+        Upgradeable::_upgrade(impl_hash)
     }
 
     // --- Ownership ---

--- a/contracts/src/ocr2/aggregator.cairo
+++ b/contracts/src/ocr2/aggregator.cairo
@@ -297,9 +297,9 @@ mod Aggregator {
     // --- Upgradeable ---
 
     #[external]
-    fn upgrade(new_class_hash: ClassHash) {
+    fn upgrade(new_impl: ClassHash) {
         Ownable::assert_only_owner();
-        Upgradeable::upgrade(new_class_hash)
+        Upgradeable::upgrade(new_impl)
     }
 
     // --- Ownership ---

--- a/contracts/src/ocr2/aggregator_proxy.cairo
+++ b/contracts/src/ocr2/aggregator_proxy.cairo
@@ -189,9 +189,9 @@ mod AggregatorProxy {
     // -- Upgradeable -- 
 
     #[external]
-    fn upgrade(new_class_hash: ClassHash) {
+    fn upgrade(new_impl: ClassHash) {
         Ownable::assert_only_owner();
-        Upgradeable::upgrade(new_class_hash)
+        Upgradeable::upgrade(new_impl)
     }
 
     // -- SimpleReadAccessController --

--- a/contracts/src/ocr2/aggregator_proxy.cairo
+++ b/contracts/src/ocr2/aggregator_proxy.cairo
@@ -190,7 +190,8 @@ mod AggregatorProxy {
 
     #[external]
     fn upgrade(impl_hash: ClassHash) {
-        Upgradeable::upgrade_only_owner(impl_hash)
+        Ownable::assert_only_owner();
+        Upgradeable::_upgrade(impl_hash)
     }
 
     // -- SimpleReadAccessController --

--- a/contracts/src/ocr2/aggregator_proxy.cairo
+++ b/contracts/src/ocr2/aggregator_proxy.cairo
@@ -24,6 +24,12 @@ mod AggregatorProxy {
     use super::IAggregatorDispatcher;
     use super::IAggregatorDispatcherTrait;
 
+    use integer::u128s_from_felt252;
+    use option::OptionTrait;
+    use traits::Into;
+    use traits::TryInto;
+    use zeroable::Zeroable;
+
     use starknet::ContractAddress;
     use starknet::ContractAddressIntoFelt252;
     use starknet::ContractAddressZeroable;
@@ -37,11 +43,8 @@ mod AggregatorProxy {
     use starknet::storage_read_syscall;
     use starknet::storage_write_syscall;
     use starknet::storage_address_from_base_and_offset;
-    use integer::u128s_from_felt252;
-    use option::OptionTrait;
-    use traits::Into;
-    use traits::TryInto;
-    use zeroable::Zeroable;
+    use starknet::class_hash::ClassHash;
+    use starknet::class_hash::ClassHashZeroable;
 
     use chainlink::ocr2::aggregator::IAggregator;
     use chainlink::ocr2::aggregator::Round;
@@ -49,6 +52,7 @@ mod AggregatorProxy {
     use chainlink::libraries::simple_read_access_controller::SimpleReadAccessController;
     use chainlink::libraries::simple_write_access_controller::SimpleWriteAccessController;
     use chainlink::utils::split_felt;
+    use chainlink::libraries::upgradeable::Upgradeable;
 
     const SHIFT: felt252 = 0x100000000000000000000000000000000_felt252;
     const MAX_ID: felt252 = 0xffffffffffffffffffffffffffffffff_felt252;
@@ -182,6 +186,13 @@ mod AggregatorProxy {
     #[external]
     fn renounce_ownership() {
         Ownable::renounce_ownership()
+    }
+
+    // -- Upgradeable -- 
+
+    #[external]
+    fn upgrade(impl_hash: ClassHash) {
+        Upgradeable::upgrade(impl_hash)
     }
 
     // -- SimpleReadAccessController --

--- a/contracts/src/ocr2/aggregator_proxy.cairo
+++ b/contracts/src/ocr2/aggregator_proxy.cairo
@@ -189,9 +189,9 @@ mod AggregatorProxy {
     // -- Upgradeable -- 
 
     #[external]
-    fn upgrade(impl_hash: ClassHash) {
+    fn upgrade(new_class_hash: ClassHash) {
         Ownable::assert_only_owner();
-        Upgradeable::_upgrade(impl_hash)
+        Upgradeable::upgrade(new_class_hash)
     }
 
     // -- SimpleReadAccessController --

--- a/contracts/src/ocr2/aggregator_proxy.cairo
+++ b/contracts/src/ocr2/aggregator_proxy.cairo
@@ -44,7 +44,6 @@ mod AggregatorProxy {
     use starknet::storage_write_syscall;
     use starknet::storage_address_from_base_and_offset;
     use starknet::class_hash::ClassHash;
-    use starknet::class_hash::ClassHashZeroable;
 
     use chainlink::ocr2::aggregator::IAggregator;
     use chainlink::ocr2::aggregator::Round;
@@ -192,7 +191,7 @@ mod AggregatorProxy {
 
     #[external]
     fn upgrade(impl_hash: ClassHash) {
-        Upgradeable::upgrade(impl_hash)
+        Upgradeable::upgrade_only_owner(impl_hash)
     }
 
     // -- SimpleReadAccessController --

--- a/contracts/src/tests.cairo
+++ b/contracts/src/tests.cairo
@@ -5,3 +5,4 @@ mod test_multisig;
 mod test_ownable;
 mod test_erc677;
 mod test_link_token;
+mod test_upgradeable;

--- a/contracts/src/tests.cairo
+++ b/contracts/src/tests.cairo
@@ -6,3 +6,5 @@ mod test_ownable;
 mod test_erc677;
 mod test_link_token;
 mod test_upgradeable;
+mod test_simple_write_access_controller;
+mod test_simple_read_access_controller;

--- a/contracts/src/tests/test_aggregator.cairo
+++ b/contracts/src/tests/test_aggregator.cairo
@@ -1,4 +1,13 @@
+use starknet::testing::set_caller_address;
+use starknet::ContractAddress;
+use starknet::contract_address_const;
+use starknet::class_hash::class_hash_const;
+
 use chainlink::ocr2::aggregator::pow;
+use chainlink::ocr2::aggregator::Aggregator;
+
+
+
 
 // TODO: aggregator tests
 
@@ -37,4 +46,20 @@ fn test_pow_2_0() {
     assert(pow(2, 29) == 0x20000000, 'expected 0x20000000');
     assert(pow(2, 30) == 0x40000000, 'expected 0x40000000');
     assert(pow(2, 31) == 0x80000000, 'expected 0x80000000');
+}
+
+fn setup() -> ContractAddress {
+    let account: ContractAddress = contract_address_const::<777>();
+    set_caller_address(account);
+    account
+}
+
+
+#[test]
+#[available_gas(2000000)]
+#[should_panic(expected: ('Ownable: caller is not owner', ))]
+fn test_upgrade_non_owner() {
+    let sender = setup();
+    Aggregator::upgrade(class_hash_const::<123>());
+
 }

--- a/contracts/src/tests/test_aggregator_proxy.cairo
+++ b/contracts/src/tests/test_aggregator_proxy.cairo
@@ -1,0 +1,21 @@
+use starknet::testing::set_caller_address;
+use starknet::ContractAddress;
+use starknet::contract_address_const;
+use starknet::class_hash::class_hash_const;
+
+use chainlink::ocr2::aggregator_proxy::AggregatorProxy;
+
+fn setup() -> ContractAddress {
+    let account: ContractAddress = contract_address_const::<777>();
+    set_caller_address(account);
+    account
+}
+
+#[test]
+#[available_gas(2000000)]
+#[should_panic(expected: ('Ownable: caller is not owner', ))]
+fn test_upgrade_non_owner() {
+    let sender = setup();
+    AggregatorProxy::upgrade(class_hash_const::<123>());
+
+}

--- a/contracts/src/tests/test_multisig.cairo
+++ b/contracts/src/tests/test_multisig.cairo
@@ -3,6 +3,7 @@ use starknet::contract_address_const;
 use starknet::testing::set_caller_address;
 use chainlink::multisig::assert_unique_values;
 use chainlink::multisig::Multisig;
+use starknet::class_hash::class_hash_const;
 
 // TODO: test execute_confirmation happy path with mocked
 // call_contract_syscall
@@ -280,3 +281,25 @@ fn test_execute_confirmation_below_threshold() {
     Multisig::confirm_transaction(nonce: 0);
     Multisig::execute_transaction(nonce: 0);
 }
+
+#[test]
+#[available_gas(2000000)]
+#[should_panic(expected = ('only multisig allowed', ))]
+fn test_upgrade_not_multisig() {
+    let account = contract_address_const::<777>();
+    set_caller_address(account);
+
+    Multisig::upgrade(class_hash_const::<1>())
+}
+
+// wait until replace_class_syscall is implemented by cairo test
+#[test]
+#[ignore]
+#[available_gas(2000000)]
+fn test_upgrade() {
+    // deploy multisig contract
+    // get address of multisig contract 
+    // set sender to different address than multisig contract
+    // call Multisig::upgrade(class_hash_const::<1>())
+}
+

--- a/contracts/src/tests/test_multisig.cairo
+++ b/contracts/src/tests/test_multisig.cairo
@@ -279,22 +279,11 @@ fn test_execute_confirmation_below_threshold() {
 
 #[test]
 #[available_gas(2000000)]
-#[should_panic(expected = ('only multisig allowed', ))]
+#[should_panic(expected: ('only multisig allowed', ))]
 fn test_upgrade_not_multisig() {
     let account = contract_address_const::<777>();
     set_caller_address(account);
 
     Multisig::upgrade(class_hash_const::<1>())
-}
-
-// wait until replace_class_syscall is implemented by cairo test
-#[test]
-#[ignore]
-#[available_gas(2000000)]
-fn test_upgrade() {
-    // deploy multisig contract
-    // get address of multisig contract 
-    // set sender to different address than multisig contract
-    // call Multisig::upgrade(class_hash_const::<1>())
 }
 

--- a/contracts/src/tests/test_simple_read_access_controller.cairo
+++ b/contracts/src/tests/test_simple_read_access_controller.cairo
@@ -1,0 +1,21 @@
+use starknet::ContractAddress;
+use starknet::testing::set_caller_address;
+use starknet::contract_address_const;
+use starknet::class_hash::class_hash_const;
+
+use chainlink::libraries::simple_read_access_controller::SimpleReadAccessController;
+
+fn setup() -> ContractAddress {
+    let account: ContractAddress = contract_address_const::<777>();
+    set_caller_address(account);
+    account
+}
+
+#[test]
+#[available_gas(2000000)]
+#[should_panic(expected: ('Ownable: caller is not owner', ))]
+fn test_upgrade_not_owner() {
+    let sender = setup();
+
+    SimpleReadAccessController::upgrade(class_hash_const::<2>());
+}

--- a/contracts/src/tests/test_simple_write_access_controller.cairo
+++ b/contracts/src/tests/test_simple_write_access_controller.cairo
@@ -1,0 +1,21 @@
+use starknet::ContractAddress;
+use starknet::testing::set_caller_address;
+use starknet::contract_address_const;
+use starknet::class_hash::class_hash_const;
+
+use chainlink::libraries::simple_write_access_controller::SimpleWriteAccessController;
+
+fn setup() -> ContractAddress {
+    let account: ContractAddress = contract_address_const::<777>();
+    set_caller_address(account);
+    account
+}
+
+#[test]
+#[available_gas(2000000)]
+#[should_panic(expected: ('Ownable: caller is not owner', ))]
+fn test_upgrade_not_owner() {
+    let sender = setup();
+
+    SimpleWriteAccessController::upgrade(class_hash_const::<2>());
+}

--- a/contracts/src/tests/test_upgradeable.cairo
+++ b/contracts/src/tests/test_upgradeable.cairo
@@ -42,7 +42,7 @@ fn setup() -> ContractAddress {
 fn test_upgrade() {
     let sender = setup();
 
-    Upgradeable::_upgrade(class_hash_const::<1>());
+    Upgradeable::upgrade(class_hash_const::<1>());
 }
 
 #[test]
@@ -51,6 +51,6 @@ fn test_upgrade() {
 fn test_upgrade_zero_hash() {
     let sender = setup();
 
-    Upgradeable::_upgrade(class_hash_const::<0>());
+    Upgradeable::upgrade(class_hash_const::<0>());
 }
 

--- a/contracts/src/tests/test_upgradeable.cairo
+++ b/contracts/src/tests/test_upgradeable.cairo
@@ -15,34 +15,42 @@ fn setup() -> ContractAddress {
     account
 }
 
-#[test]
-#[available_gas(2000000)]
-#[should_panic(expected = ('Ownable: caller is not owner', ))]
-fn test_upgrade_non_owner() {
-    let sender = setup();
+// #[test]
+// #[available_gas(2000000)]
+// #[should_panic(expected = ('Ownable: caller is not owner', ))]
+// fn test_upgrade_non_owner() {
+//     let sender = setup();
 
-    Upgradeable::upgrade_only_owner(class_hash_const::<1>());
-}
+//     Upgradeable::upgrade_only_owner(class_hash_const::<1>());
+// }
 
-#[test]
-#[available_gas(2000000)]
-#[should_panic(expected = ('Class hash cannot be zero', ))]
-fn test_upgrade_zero_hash() {
-    let sender = setup();
+// #[test]
+// #[available_gas(2000000)]
+// #[should_panic(expected = ('Class hash cannot be zero', ))]
+// fn test_upgrade_zero_hash() {
+//     let sender = setup();
 
-    Ownable::constructor(sender);
+//     Ownable::constructor(sender);
 
-    Upgradeable::upgrade_only_owner(class_hash_const::<0>());
-}
+//     Upgradeable::upgrade_only_owner(class_hash_const::<0>());
+// }
 
 // replace_class_syscall() not yet supported in tests
 #[test]
 #[ignore]
 #[available_gas(2000000)]
-fn test_upgrade_hash() {
+fn test_upgrade() {
     let sender = setup();
 
-    Ownable::constructor(sender);
-
-    Upgradeable::upgrade_only_owner(class_hash_const::<1>());
+    Upgradeable::_upgrade(class_hash_const::<1>());
 }
+
+#[test]
+#[available_gas(2000000)]
+#[should_panic(expected: ('Class hash cannot be zero', ))]
+fn test_upgrade_zero_hash() {
+    let sender = setup();
+
+    Upgradeable::_upgrade(class_hash_const::<0>());
+}
+

--- a/contracts/src/tests/test_upgradeable.cairo
+++ b/contracts/src/tests/test_upgradeable.cairo
@@ -1,0 +1,48 @@
+use traits::Into;
+
+use starknet::testing::set_caller_address;
+use starknet::ContractAddress;
+use starknet::contract_address_const;
+use starknet::class_hash::class_hash_const;
+
+use chainlink::libraries::upgradeable::Upgradeable;
+use chainlink::libraries::ownable::Ownable;
+
+
+fn setup() -> ContractAddress {
+    let account: ContractAddress = contract_address_const::<777>();
+    set_caller_address(account);
+    account
+}
+
+#[test]
+#[available_gas(2000000)]
+#[should_panic(expected = ('Ownable: caller is not owner', ))]
+fn test_upgrade_non_owner() {
+    let sender = setup();
+
+    Upgradeable::upgrade(class_hash_const::<1>());
+}
+
+#[test]
+#[available_gas(2000000)]
+#[should_panic(expected = ('Class hash cannot be zero', ))]
+fn test_upgrade_zero_hash() {
+    let sender = setup();
+
+    Ownable::constructor(sender);
+
+    Upgradeable::upgrade(class_hash_const::<0>());
+}
+
+// replace_class_syscall() not yet supported in tests
+#[test]
+#[ignore]
+#[available_gas(2000000)]
+fn test_upgrade_hash() {
+    let sender = setup();
+
+    Ownable::constructor(sender);
+
+    Upgradeable::upgrade(class_hash_const::<1>());
+}

--- a/contracts/src/tests/test_upgradeable.cairo
+++ b/contracts/src/tests/test_upgradeable.cairo
@@ -21,7 +21,7 @@ fn setup() -> ContractAddress {
 fn test_upgrade_non_owner() {
     let sender = setup();
 
-    Upgradeable::upgrade(class_hash_const::<1>());
+    Upgradeable::upgrade_only_owner(class_hash_const::<1>());
 }
 
 #[test]
@@ -32,7 +32,7 @@ fn test_upgrade_zero_hash() {
 
     Ownable::constructor(sender);
 
-    Upgradeable::upgrade(class_hash_const::<0>());
+    Upgradeable::upgrade_only_owner(class_hash_const::<0>());
 }
 
 // replace_class_syscall() not yet supported in tests
@@ -44,5 +44,5 @@ fn test_upgrade_hash() {
 
     Ownable::constructor(sender);
 
-    Upgradeable::upgrade(class_hash_const::<1>());
+    Upgradeable::upgrade_only_owner(class_hash_const::<1>());
 }

--- a/contracts/src/tests/test_upgradeable.cairo
+++ b/contracts/src/tests/test_upgradeable.cairo
@@ -15,26 +15,6 @@ fn setup() -> ContractAddress {
     account
 }
 
-// #[test]
-// #[available_gas(2000000)]
-// #[should_panic(expected = ('Ownable: caller is not owner', ))]
-// fn test_upgrade_non_owner() {
-//     let sender = setup();
-
-//     Upgradeable::upgrade_only_owner(class_hash_const::<1>());
-// }
-
-// #[test]
-// #[available_gas(2000000)]
-// #[should_panic(expected = ('Class hash cannot be zero', ))]
-// fn test_upgrade_zero_hash() {
-//     let sender = setup();
-
-//     Ownable::constructor(sender);
-
-//     Upgradeable::upgrade_only_owner(class_hash_const::<0>());
-// }
-
 // replace_class_syscall() not yet supported in tests
 #[test]
 #[ignore]
@@ -53,4 +33,3 @@ fn test_upgrade_zero_hash() {
 
     Upgradeable::upgrade(class_hash_const::<0>());
 }
-

--- a/contracts/src/token/link_token.cairo
+++ b/contracts/src/token/link_token.cairo
@@ -11,14 +11,18 @@ trait IMintableToken {
 
 #[contract]
 mod LinkToken {
+    use super::IMintableToken;
+
+    use zeroable::Zeroable;
+    
     use starknet::ContractAddress;
     use starknet::ContractAddressZeroable;
-    use zeroable::Zeroable;
+    use starknet::class_hash::ClassHash;
 
     use chainlink::libraries::token::erc20::ERC20;
     use chainlink::libraries::token::erc677::ERC677;
-
-    use super::IMintableToken;
+    use chainlink::libraries::ownable::Ownable;
+    use chainlink::libraries::upgradeable::Upgradeable;
 
     const NAME: felt252 = 'ChainLink Token';
     const SYMBOL: felt252 = 'LINK';
@@ -41,10 +45,11 @@ mod LinkToken {
 
 
     #[constructor]
-    fn constructor(minter: ContractAddress) {
+    fn constructor(minter: ContractAddress, owner: ContractAddress) {
         ERC20::initializer(NAME, SYMBOL);
         assert(!minter.is_zero(), 'minter is 0');
         _minter::write(minter);
+        Ownable::initializer(owner);
     }
 
     #[view]
@@ -73,6 +78,43 @@ mod LinkToken {
     #[external]
     fn permissionedBurn(account: ContractAddress, amount: u256) {
         MintableToken::permissionedBurn(account, amount)
+    }
+
+    //
+    //  Upgradeable
+    //
+    #[external]
+    fn upgrade(impl_hash: ClassHash) {
+        Upgradeable::upgrade_only_owner(impl_hash)
+    }
+
+    //
+    // Ownership
+    //
+
+    #[view]
+    fn owner() -> ContractAddress {
+        Ownable::owner()
+    }
+
+    #[view]
+    fn proposed_owner() -> ContractAddress {
+        Ownable::proposed_owner()
+    }
+
+    #[external]
+    fn transfer_ownership(new_owner: ContractAddress) {
+        Ownable::transfer_ownership(new_owner)
+    }
+
+    #[external]
+    fn accept_ownership() {
+        Ownable::accept_ownership()
+    }
+
+    #[external]
+    fn renounce_ownership() {
+        Ownable::renounce_ownership()
     }
 
 

--- a/contracts/src/token/link_token.cairo
+++ b/contracts/src/token/link_token.cairo
@@ -83,9 +83,9 @@ mod LinkToken {
     //  Upgradeable
     //
     #[external]
-    fn upgrade(impl_hash: ClassHash) {
+    fn upgrade(new_class_hash: ClassHash) {
         Ownable::assert_only_owner();
-        Upgradeable::_upgrade(impl_hash)
+        Upgradeable::upgrade(new_class_hash)
     }
 
     //

--- a/contracts/src/token/link_token.cairo
+++ b/contracts/src/token/link_token.cairo
@@ -84,7 +84,8 @@ mod LinkToken {
     //
     #[external]
     fn upgrade(impl_hash: ClassHash) {
-        Upgradeable::upgrade_only_owner(impl_hash)
+        Ownable::assert_only_owner();
+        Upgradeable::_upgrade(impl_hash)
     }
 
     //

--- a/contracts/src/token/link_token.cairo
+++ b/contracts/src/token/link_token.cairo
@@ -83,9 +83,9 @@ mod LinkToken {
     //  Upgradeable
     //
     #[external]
-    fn upgrade(new_class_hash: ClassHash) {
+    fn upgrade(new_impl: ClassHash) {
         Ownable::assert_only_owner();
-        Upgradeable::upgrade(new_class_hash)
+        Upgradeable::upgrade(new_impl)
     }
 
     //
@@ -185,8 +185,6 @@ mod LinkToken {
     fn only_minter() {
         let caller = starknet::get_caller_address();
         let minter = minter();
-        // todo: can we remove this check because it's already in the constructor
-        assert(!minter.is_zero(), 'minter is 0');
         assert(caller == minter, 'only minter');
     }
 }


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCI-1259

The reasoning behind making contracts upgradeable is because in the shifting landscape of Starknet, there may be feature deprecation and/or unknown changes required. ~This PR only makes the core data feed contracts (uptime feed, aggregator, and proxy aggregator) upgradeable. However, I think we should discuss if we want to make the multisig contract and link token upgradeable because they'd be equally affected by breaking changes as the core data feed contracts.~ We reached a team decision to make all contracts that we own upgradeable

Notes:
* ~Contracts such as Ownable, SimpleReadAccessController, etc. don't have upgrade external functions because they are used as libraries and never intended to be deployed by themselves~ access controllers need to be deployed as contracts so they are upgradeable as well
* ~I included the Ownable:assert_only_owner() in the upgradeable library~ ownable assertion not imported to reduce dependencies
* I can't actually test the replace class hash syscall yet because cairo test does not support it yet (even in rc0) --> we will test the functionality on devnet in a seperate PR



