### PR TITLE
Refactor Sign func

### DIFF
--- a/relayer/pkg/chainlink/keys/key.go
+++ b/relayer/pkg/chainlink/keys/key.go
@@ -106,6 +106,9 @@ func (key Key) PublicKey() PublicKey {
 	return key.pub
 }
 
+// Sign creates a signature by concat'ing the public key, and the curve parameters r,s.
+//
+//	public key (32 bytes) + r (32 bytes) + s (32 bytes)
 func Sign(hash *big.Int, key Key) ([]byte, error) {
 
 	r, s, err := caigo.Curve.Sign(hash, key.ToPrivKey())

--- a/relayer/pkg/chainlink/keys/key_test.go
+++ b/relayer/pkg/chainlink/keys/key_test.go
@@ -1,0 +1,22 @@
+package keys_test
+
+import (
+	"crypto/rand"
+	"math/big"
+	"testing"
+
+	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/keys"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSign(t *testing.T) {
+	k, err := keys.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+
+	x := big.NewInt(123456)
+
+	signature, err := keys.Sign(x, k)
+	require.NoError(t, err)
+	require.Len(t, signature, 3*32)
+	require.Equal(t, []byte(keys.PubKeyToStarkKey(k.PublicKey())), signature[:32])
+}

--- a/relayer/pkg/chainlink/keys/ocr2key.go
+++ b/relayer/pkg/chainlink/keys/ocr2key.go
@@ -1,13 +1,12 @@
 package keys
 
 import (
-	"bytes"
 	"io"
 	"math/big"
 
 	"github.com/NethermindEth/juno/pkg/crypto/pedersen"
-	"github.com/smartcontractkit/caigo"
 	"github.com/pkg/errors"
+	"github.com/smartcontractkit/caigo"
 
 	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/chainlink/ocr2/medianreport"
 	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/starknet"
@@ -58,30 +57,7 @@ func (sk *OCR2Key) Sign(reportCtx ocrtypes.ReportContext, report ocrtypes.Report
 		return []byte{}, err
 	}
 
-	r, s, err := caigo.Curve.Sign(hash, sk.priv)
-	if err != nil {
-		return []byte{}, err
-	}
-
-	// enforce s <= N/2 to prevent signature malleability
-	if s.Cmp(new(big.Int).Rsh(caigo.Curve.N, 1)) > 0 {
-		s.Sub(caigo.Curve.N, s)
-	}
-
-	// encoding: public key (32 bytes) + r (32 bytes) + s (32 bytes)
-	buff := bytes.NewBuffer([]byte(sk.PublicKey()))
-	if _, err := buff.Write(starknet.PadBytes(r.Bytes(), byteLen)); err != nil {
-		return []byte{}, err
-	}
-	if _, err := buff.Write(starknet.PadBytes(s.Bytes(), byteLen)); err != nil {
-		return []byte{}, err
-	}
-
-	out := buff.Bytes()
-	if len(out) != sk.MaxSignatureLength() {
-		return []byte{}, errors.Errorf("unexpected signature size, got %d want %d", len(out), sk.MaxSignatureLength())
-	}
-	return out, nil
+	return Sign(hash, sk.Key)
 }
 
 func (sk *OCR2Key) Verify(publicKey ocrtypes.OnchainPublicKey, reportCtx ocrtypes.ReportContext, report ocrtypes.Report, signature []byte) bool {


### PR DESCRIPTION
LOOP interface requires a Keystore interface that can Sign.

This change refactors the signature implement in ocr2keys to a common utility that can be used in other packages