### PR TITLE
Integration tests for LOOPp

### DIFF
--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -107,7 +107,7 @@ jobs:
     runs-on: ubuntu20.04-16cores-64GB
     needs: [ build_custom_chainlink_image, build_test_image ]
     environment: integration
-    # these values need to match those used when building the chainlink image
+    # these values need to match those used to build the chainlink image
     strategy:
       matrix:
         image:

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           cl_repo: smartcontractkit/chainlink
           #cl_ref: ${{ github.event.inputs.cl_branch_ref }}
-          cl_ref: d77e53f75ae75346de0231840958a87fba358713
+          cl_ref: 84a29975d4702f8156b41a3c4b731b0c76998311
           cl_dockerfile: plugins/chainlink.Dockerfile
           # commit of the caller branch
           dep_starknet_sha: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           cl_repo: smartcontractkit/chainlink
           #cl_ref: ${{ github.event.inputs.cl_branch_ref }}
-          cl_ref: 4814df6540c27e6c1e0ffd0c97a33577f674e58d
+          cl_ref: d77e53f75ae75346de0231840958a87fba358713
           cl_dockerfile: plugins/chainlink.Dockerfile
           # commit of the caller branch
           dep_starknet_sha: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -54,6 +54,7 @@ jobs:
         with:
           cl_repo: smartcontractkit/chainlink
           cl_ref: ${{ github.event.inputs.cl_branch_ref }}
+          cl_dockerfile: plugins/chainlink.Dockerfile
           # commit of the caller branch
           dep_starknet_sha: ${{ github.event.pull_request.head.sha || github.sha }}
           push_tag: ${{ env.CL_ECR }}:starknet.${{ github.sha }}

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -29,6 +29,15 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    strategy:
+      matrix:
+        image:
+          - name: ""
+            dockerfile: core/chainlink.Dockerfile
+            tag-suffix: ""
+          - name: (plugins)
+            dockerfile: plugins/chainlink.Dockerfile
+            tag-suffix: -plugins
     steps:
       - name: Collect Metrics
         if: always()
@@ -44,28 +53,27 @@ jobs:
         uses: smartcontractkit/chainlink-github-actions/docker/image-exists@2c9f401149f6c25fb632067b7e6626aebeee5d69 # v2.1.6
         with:
           repository: chainlink
-          tag: starknet.${{ github.sha }}
+          tag: starknet.${{ github.sha }}${{ matrix.image.tag-suffix }}
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-      - name: Build Image
+      - name: Build Image ${{ matrix.image.name }}
         if: steps.check-image.outputs.exists == 'false'
         # note using a temporary commit for build-image that works around the go get issues, replace when go get issues are fixed please
         uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@2c9f401149f6c25fb632067b7e6626aebeee5d69
         with:
           cl_repo: smartcontractkit/chainlink
-          #cl_ref: ${{ github.event.inputs.cl_branch_ref }}
-          cl_ref: 84a29975d4702f8156b41a3c4b731b0c76998311
-          cl_dockerfile: plugins/chainlink.Dockerfile
+          cl_ref: ${{ github.event.inputs.cl_branch_ref }}
+          cl_dockerfile: ${{ matrix.image.dockerfile }}
           # commit of the caller branch
           dep_starknet_sha: ${{ github.event.pull_request.head.sha || github.sha }}
-          push_tag: ${{ env.CL_ECR }}:starknet.${{ github.sha }}
+          push_tag: ${{ env.CL_ECR }}:starknet.${{ github.sha }}${{ matrix.image.tag-suffix }}
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           QA_PRIVATE_GHA_PULL: ${{ secrets.QA_PRIVATE_GHA_PULL }}
       - name: Print Chainlink Image Built
         run: |
           echo "### chainlink image tag used for this test run :link:" >> $GITHUB_STEP_SUMMARY
-          echo "\`starknet.${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "\`starknet.${{ github.sha }}${{ matrix.image.tag-suffix }}\`" >> $GITHUB_STEP_SUMMARY
 
   build_test_image:
     environment: integration
@@ -99,6 +107,14 @@ jobs:
     runs-on: ubuntu20.04-16cores-64GB
     needs: [ build_custom_chainlink_image, build_test_image ]
     environment: integration
+    # these values need to match those used when building the chainlink image
+    strategy:
+      matrix:
+        image:
+          - name: ""
+            tag-suffix: ""
+          - name: (plugins)
+            tag-suffix: -plugins
     env:
       TEST_SUITE: smoke
       TEST_ARGS: -test.timeout 1h
@@ -120,7 +136,7 @@ jobs:
         with:
           basic-auth: ${{ secrets.GRAFANA_CLOUD_BASIC_AUTH }}
           hostname: ${{ secrets.GRAFANA_CLOUD_HOST }}
-          this-job-name: Run Smoke Tests
+          this-job-name: Run Smoke Tests ${{ matrix.image.name }}
         continue-on-error: true
       - name: Checkout the repo
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
@@ -128,13 +144,13 @@ jobs:
         uses: cachix/install-nix-action@29bd9290ef037a3ecbdafe83cbd2185e9dd0fa0a # v20
         with:
           nix_path: nixpkgs=channel:nixos-unstable
-      - name: Run Tests
+      - name: Run Tests ${{ matrix.image.name }}
         uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/run-tests@2c9f401149f6c25fb632067b7e6626aebeee5d69
         with:
           test_command_to_run: nix develop -c make test-integration-smoke-ci
           test_download_vendor_packages_command: cd integration-tests && nix develop -c go mod download
           cl_repo: ${{ env.CL_ECR }}
-          cl_image_tag: starknet.${{ github.sha }}
+          cl_image_tag: starknet.${{ github.sha }}${{ matrix.image.tag-suffix }}
           token: ${{ secrets.GITHUB_TOKEN }}
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -53,7 +53,8 @@ jobs:
         uses: smartcontractkit/chainlink-github-actions/chainlink-testing-framework/build-image@2c9f401149f6c25fb632067b7e6626aebeee5d69
         with:
           cl_repo: smartcontractkit/chainlink
-          cl_ref: ${{ github.event.inputs.cl_branch_ref }}
+          #cl_ref: ${{ github.event.inputs.cl_branch_ref }}
+          cl_ref: 8316a9132265e3cc8a2255ef2e5102f2bedc551b
           cl_dockerfile: plugins/chainlink.Dockerfile
           # commit of the caller branch
           dep_starknet_sha: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -54,7 +54,7 @@ jobs:
         with:
           cl_repo: smartcontractkit/chainlink
           #cl_ref: ${{ github.event.inputs.cl_branch_ref }}
-          cl_ref: 8316a9132265e3cc8a2255ef2e5102f2bedc551b
+          cl_ref: 4814df6540c27e6c1e0ffd0c97a33577f674e58d
           cl_dockerfile: plugins/chainlink.Dockerfile
           # commit of the caller branch
           dep_starknet_sha: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/docs/integration-tests/README.md
+++ b/docs/integration-tests/README.md
@@ -218,7 +218,7 @@ yarn gauntlet ocr2:set_billing --observationPaymentGjuels=<value> --transmission
                "alphaAcceptPpb": 0,
                "deltaCNanoseconds": 1000000000
            },
-           "maxDurationQueryNanoseconds": 0,
+           "maxDurationQueryNanoseconds": 2000000000,
            "maxDurationObservationNanoseconds": 1000000000,
            "maxDurationReportNanoseconds": 2000000000,
            "maxDurationShouldAcceptFinalizedReportNanoseconds": 2000000000,

--- a/integration-tests/go.mod
+++ b/integration-tests/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b
 	github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e
 	github.com/smartcontractkit/chainlink-env v0.3.29
-	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086
+	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545
 	github.com/smartcontractkit/chainlink-starknet/ops v0.0.0-20230329050701-40e3b18bb026
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230530233948-90c8af98011e
 	github.com/smartcontractkit/chainlink-testing-framework v1.11.5

--- a/integration-tests/go.sum
+++ b/integration-tests/go.sum
@@ -1321,8 +1321,8 @@ github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e/go.mod h1:2
 github.com/smartcontractkit/chainlink-cosmos v0.4.0 h1:xYLAcJJIm0cyMtYtMaosO45bykEwcwQOmZz3mz46Y2A=
 github.com/smartcontractkit/chainlink-env v0.3.29 h1:hcIw/BeuB0wKiiE3umAUNBZzWkHO24XF3OW9xSrlMbI=
 github.com/smartcontractkit/chainlink-env v0.3.29/go.mod h1:9c0Czq4a6wZKY20BcoAlK29DnejQIiLo/MwKYtSFnHk=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086 h1:d2WiCTnsCtA16KVabnX3E9SZH1irp2/d0MLT0/UI3XY=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086/go.mod h1:zfUba6Okm7zTBxap24I78Vq9z+twHmjXSMBAl2C2Qgc=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545 h1:RrapLM49rs6WThQre+AfvpO9qFQZA2jaq0l9KImxT8c=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545/go.mod h1:zfUba6Okm7zTBxap24I78Vq9z+twHmjXSMBAl2C2Qgc=
 github.com/smartcontractkit/chainlink-solana v1.0.3-0.20230518143827-0b7a6e43719c h1:pM7FH+S92F7Xa/VSfbIs941FDKqSmo9pYeUBWHl1Pq0=
 github.com/smartcontractkit/chainlink-testing-framework v1.11.5 h1:gYSnOQhLxgE0mxwnv015nNnPgH9kcosx+AzPboEFo38=
 github.com/smartcontractkit/chainlink-testing-framework v1.11.5/go.mod h1:0ktPcDE5fFSvNewsaHuC4tGVaiCMQsl5RN/cWO5k0rg=

--- a/monitoring/go.mod
+++ b/monitoring/go.mod
@@ -5,7 +5,7 @@ go 1.20
 require (
 	github.com/prometheus/client_golang v1.14.0
 	github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e
-	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086
+	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545
 	github.com/smartcontractkit/chainlink-starknet/relayer v0.0.0-20230508053614-9f2fd5fd4ff1
 	github.com/smartcontractkit/libocr v0.0.0-20230525150148-a75f6e244bb3
 	github.com/stretchr/testify v1.8.2

--- a/monitoring/go.sum
+++ b/monitoring/go.sum
@@ -210,8 +210,8 @@ github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKl
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e h1:XY8DncHICYQ1WDVpoXM7Tv3tztNHa1/DctDlSmqgU10=
 github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086 h1:d2WiCTnsCtA16KVabnX3E9SZH1irp2/d0MLT0/UI3XY=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086/go.mod h1:zfUba6Okm7zTBxap24I78Vq9z+twHmjXSMBAl2C2Qgc=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545 h1:RrapLM49rs6WThQre+AfvpO9qFQZA2jaq0l9KImxT8c=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545/go.mod h1:zfUba6Okm7zTBxap24I78Vq9z+twHmjXSMBAl2C2Qgc=
 github.com/smartcontractkit/libocr v0.0.0-20230525150148-a75f6e244bb3 h1:/Gel/U5eIZ/BGGr25OrHaXiVDTAJ5DYX5+UlXp3q7Gg=
 github.com/smartcontractkit/libocr v0.0.0-20230525150148-a75f6e244bb3/go.mod h1:5JnCHuYgmIP9ZyXzgAfI5Iwu0WxBtBKp+ApeT5o1Cjw=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=

--- a/ops/go.mod
+++ b/ops/go.mod
@@ -99,7 +99,7 @@ require (
 	github.com/rogpeppe/go-internal v1.10.0 // indirect
 	github.com/russross/blackfriday v1.6.0 // indirect
 	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
-	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086 // indirect
+	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545 // indirect
 	github.com/smartcontractkit/libocr v0.0.0-20230525150148-a75f6e244bb3 // indirect
 	github.com/spf13/cobra v1.6.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/ops/go.sum
+++ b/ops/go.sum
@@ -316,8 +316,8 @@ github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e h1:XY8DncHI
 github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
 github.com/smartcontractkit/chainlink-env v0.3.29 h1:hcIw/BeuB0wKiiE3umAUNBZzWkHO24XF3OW9xSrlMbI=
 github.com/smartcontractkit/chainlink-env v0.3.29/go.mod h1:9c0Czq4a6wZKY20BcoAlK29DnejQIiLo/MwKYtSFnHk=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086 h1:d2WiCTnsCtA16KVabnX3E9SZH1irp2/d0MLT0/UI3XY=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086/go.mod h1:zfUba6Okm7zTBxap24I78Vq9z+twHmjXSMBAl2C2Qgc=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545 h1:RrapLM49rs6WThQre+AfvpO9qFQZA2jaq0l9KImxT8c=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545/go.mod h1:zfUba6Okm7zTBxap24I78Vq9z+twHmjXSMBAl2C2Qgc=
 github.com/smartcontractkit/chainlink-testing-framework v1.11.5 h1:gYSnOQhLxgE0mxwnv015nNnPgH9kcosx+AzPboEFo38=
 github.com/smartcontractkit/chainlink-testing-framework v1.11.5/go.mod h1:0ktPcDE5fFSvNewsaHuC4tGVaiCMQsl5RN/cWO5k0rg=
 github.com/smartcontractkit/libocr v0.0.0-20230525150148-a75f6e244bb3 h1:/Gel/U5eIZ/BGGr25OrHaXiVDTAJ5DYX5+UlXp3q7Gg=

--- a/ops/test_helpers.go
+++ b/ops/test_helpers.go
@@ -76,7 +76,7 @@ var TestOCR2Config = OCR2Config{
 			AlphaAcceptPpb:      0,
 			DeltaCNanoseconds:   1000000000,
 		},
-		MaxDurationQueryNanoseconds:                        0,
+		MaxDurationQueryNanoseconds:                        2000000000,
 		MaxDurationObservationNanoseconds:                  1000000000,
 		MaxDurationReportNanoseconds:                       2000000000,
 		MaxDurationShouldAcceptFinalizedReportNanoseconds:  2000000000,

--- a/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
@@ -59,7 +59,7 @@ const validInput = {
       alphaAcceptPpb: 0,
       deltaCNanoseconds: 0,
     },
-    maxDurationQueryNanoseconds: 0,
+    maxDurationQueryNanoseconds: 2000000000,
     maxDurationObservationNanoseconds: 1000000000,
     maxDurationReportNanoseconds: 200000000,
     maxDurationShouldAcceptFinalizedReportNanoseconds: 200000000,

--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/btcsuite/btcd/chaincfg/chainhash v1.0.1
 	github.com/pkg/errors v0.9.1
 	github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e
-	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086
+	github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545
 	github.com/smartcontractkit/libocr v0.0.0-20230525150148-a75f6e244bb3
 	github.com/stretchr/testify v1.8.2
 	go.uber.org/zap v1.24.0

--- a/relayer/go.sum
+++ b/relayer/go.sum
@@ -119,8 +119,8 @@ github.com/shirou/gopsutil v3.21.11+incompatible h1:+1+c1VGhc88SSonWP6foOcLhvnKl
 github.com/shirou/gopsutil v3.21.11+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e h1:XY8DncHICYQ1WDVpoXM7Tv3tztNHa1/DctDlSmqgU10=
 github.com/smartcontractkit/caigo v0.0.0-20230530082629-53a5a4bdb25e/go.mod h1:2QuJdEouTWjh5BDy5o/vgGXQtR4Gz8yH1IYB5eT7u4M=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086 h1:d2WiCTnsCtA16KVabnX3E9SZH1irp2/d0MLT0/UI3XY=
-github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230531014621-9c303da4c086/go.mod h1:zfUba6Okm7zTBxap24I78Vq9z+twHmjXSMBAl2C2Qgc=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545 h1:RrapLM49rs6WThQre+AfvpO9qFQZA2jaq0l9KImxT8c=
+github.com/smartcontractkit/chainlink-relay v0.1.7-0.20230605232729-e0a00f8c6545/go.mod h1:zfUba6Okm7zTBxap24I78Vq9z+twHmjXSMBAl2C2Qgc=
 github.com/smartcontractkit/libocr v0.0.0-20230525150148-a75f6e244bb3 h1:/Gel/U5eIZ/BGGr25OrHaXiVDTAJ5DYX5+UlXp3q7Gg=
 github.com/smartcontractkit/libocr v0.0.0-20230525150148-a75f6e244bb3/go.mod h1:5JnCHuYgmIP9ZyXzgAfI5Iwu0WxBtBKp+ApeT5o1Cjw=
 github.com/status-im/keycard-go v0.2.0 h1:QDLFswOQu1r5jsycloeQh3bVU8n/NatHHaZobtDnDzA=


### PR DESCRIPTION
Add test matrix for LOOPp Relayer.

Taken from the solana CI test in core https://github.com/smartcontractkit/chainlink/blob/a4534e774e11655ef4f2fb5bd085b8a4f43da49f/.github/workflows/integration-tests.yml#L56

validated that both software version ran by reading the logs in grafana
non-LOOPp namespace: chainlink-ocr-starknet-68432 https://chainlinklabs.grafana.net/goto/jmV2F2_Vg?orgId=1
LOOPP namespace: chainlink-ocr-starknet-f8aa1 https://chainlinklabs.grafana.net/goto/CDBcF2_4R?orgId=1
