### PR TITLE
fix monitoring CI build, copy relayer code

### DIFF
--- a/.github/workflows/monitoring-build-push-ecr.yml
+++ b/.github/workflows/monitoring-build-push-ecr.yml
@@ -6,6 +6,7 @@ on:
       - develop
     paths:
       - monitoring/**
+      - relayer/**
 
 jobs:
   build-and-publish-monitoring:
@@ -46,7 +47,7 @@ jobs:
         uses: docker/build-push-action@c56af957549030174b10d6867f20e78cfd7debc5 # v3.2.0
         with:
           push: true
-          context: monitoring
+          context: ./
           file: monitoring/ops/Dockerfile
           tags: ${{ steps.docker_meta.outputs.tags }}
           labels: ${{ steps.docker_meta.outputs.labels }}

--- a/monitoring/ops/Dockerfile
+++ b/monitoring/ops/Dockerfile
@@ -4,15 +4,18 @@ FROM golang:1.20-buster as build
 
 # Copy source
 
-RUN mkdir -p /starknet-monitoring/cmd
-COPY ./cmd/monitoring /starknet-monitoring/cmd/monitoring
-COPY ./pkg /starknet-monitoring/pkg
-COPY ./go.mod /starknet-monitoring/
-COPY ./go.sum /starknet-monitoring/
+RUN mkdir -p /build/starknet-monitoring/cmd
+COPY ./monitoring/cmd/monitoring /build/starknet-monitoring/cmd/monitoring
+COPY ./monitoring/pkg /build/starknet-monitoring/pkg
+COPY ./monitoring/go.mod /build/starknet-monitoring/
+COPY ./monitoring/go.sum /build/starknet-monitoring/
+
+# Copy relayer
+COPY ./relayer /build/relayer
 
 # Compile binary
 
-WORKDIR /starknet-monitoring
+WORKDIR /build/starknet-monitoring
 RUN go build -o ./monitoring ./cmd/monitoring/*.go
 
 # Production image
@@ -20,7 +23,7 @@ RUN go build -o ./monitoring ./cmd/monitoring/*.go
 FROM ubuntu:20.04
 
 RUN apt-get update && apt-get install -y ca-certificates
-COPY --from=build /starknet-monitoring/monitoring /monitoring
+COPY --from=build /build/starknet-monitoring/monitoring /monitoring
 
 # Expose prometheus default port
 EXPOSE 9090/tcp


### PR DESCRIPTION
test runs on `develop` push all fail due to missing relayer code: https://github.com/smartcontractkit/chainlink-starknet/actions/runs/5204154566/jobs/9387990799

successful test run: https://github.com/smartcontractkit/chainlink-starknet/actions/runs/5207518255/jobs/9395150008?pr=300