### PR TITLE
BCI-1377: Add Upgrade commands in gauntlet

### DIFF
--- a/packages-ts/starknet-gauntlet-emergency-protocol/README.md
+++ b/packages-ts/starknet-gauntlet-emergency-protocol/README.md
@@ -88,6 +88,14 @@ This sets the L1 sender address. This is to control, which L1 address can write 
 yarn gauntlet sequencer_uptime_feed:set_l1_sender --network=<NETWORK> --address=<ADDRESS>  <L2_FEED>
 ```
 
+- upgrade
+
+This upgrades the contract to point to a new class hash. 
+
+```bash
+yarn gauntlet SequencerUptimeFeed:upgrade --network=testnet --classHash=<CLASS_HASH>
+```
+
 - Inspect
 
 Inspect the latest round data

--- a/packages-ts/starknet-gauntlet-emergency-protocol/src/commands/sequencerUptimeFeed/index.ts
+++ b/packages-ts/starknet-gauntlet-emergency-protocol/src/commands/sequencerUptimeFeed/index.ts
@@ -1,7 +1,8 @@
 import Deploy from './deploy'
 import SetL1Sender from './setL1Sender'
+import Upgrade from './upgrade'
 
 import Inspection from './inspection'
 
-export const executionCommands = [Deploy, SetL1Sender]
+export const executionCommands = [Deploy, SetL1Sender, Upgrade]
 export const inspectionCommands = [...Inspection]

--- a/packages-ts/starknet-gauntlet-emergency-protocol/src/commands/sequencerUptimeFeed/upgrade.ts
+++ b/packages-ts/starknet-gauntlet-emergency-protocol/src/commands/sequencerUptimeFeed/upgrade.ts
@@ -1,0 +1,11 @@
+import { makeExecuteCommand, upgradeCommandConfig } from '@chainlink/starknet-gauntlet'
+import { CATEGORIES } from '../../lib/categories'
+import { CONTRACT_LIST, uptimeFeedContractLoader } from '../../lib/contracts'
+
+export default makeExecuteCommand(
+  upgradeCommandConfig(
+    CONTRACT_LIST.SEQUENCER_UPTIME_FEED,
+    CATEGORIES.SEQUENCER_UPTIME_FEED,
+    uptimeFeedContractLoader,
+  ),
+)

--- a/packages-ts/starknet-gauntlet-multisig/README.md
+++ b/packages-ts/starknet-gauntlet-multisig/README.md
@@ -34,6 +34,10 @@ Threshold can only be updated through a transaction executed from the multisig i
 yarn gauntlet multisig:set_thresold:multisig --network=<NETWORK> --threshold=<APPROVALS_NEEDED> <MULTISIG_CONTRACT_ADDRESS>
 ```
 
+### Upgrade
+
+To upgrade the multisig, you will need to create a proposal calling the `upgrade` function on the multisig contract. Please read the instructions below for how to create a proposal
+
 ## Wrapping Gauntlet commands
 
 A [wrap function](./src/wrapper/index.ts#L30) is exposed from this package. It allows to wrap any Gauntlet command and make its functionality available to be executed from a multisig wallet. The process is the same for every command:

--- a/packages-ts/starknet-gauntlet-ocr2/README.md
+++ b/packages-ts/starknet-gauntlet-ocr2/README.md
@@ -55,3 +55,20 @@ yarn gauntlet ocr2:set_config --network=<NETWORK> --address=<ADDRESS> --f=<NUMBE
 ```
 
 This Should set the config for this feed on contract address.
+
+
+## Upgrading
+
+All of the contracts (besides example) can be upgraded by supplying a classHash flag
+
+e.g.
+
+```bash
+yarn gautnlet access_controller:upgrade --network=<NETWORK> --classHash=<CLASS_HASH> <CONTRACT_ADDRESS>`,
+```
+
+or
+
+```bash
+yarn gautnlet ocr2:upgrade --network=<NETWORK> --classHash=<CLASS_HASH> <CONTRACT_ADDRESS>`,
+```

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/accessController/index.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/accessController/index.ts
@@ -1,3 +1,4 @@
 import Deploy from './deploy'
+import Upgrade from './upgrade'
 
-export const executeCommands = [Deploy]
+export const executeCommands = [Deploy, Upgrade]

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/accessController/upgrade.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/accessController/upgrade.ts
@@ -1,0 +1,11 @@
+import { makeExecuteCommand, upgradeCommandConfig } from '@chainlink/starknet-gauntlet'
+import { CATEGORIES } from '../../lib/categories'
+import { accessControllerContractLoader } from '../../lib/contracts'
+
+export default makeExecuteCommand(
+  upgradeCommandConfig(
+    CATEGORIES.ACCESS_CONTROLLER,
+    CATEGORIES.ACCESS_CONTROLLER,
+    accessControllerContractLoader,
+  ),
+)

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/index.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/index.ts
@@ -1,9 +1,17 @@
 import Deploy from './deploy'
+import Upgrade from './upgrade'
 import inspect from './inspection/inspect'
 import SetBilling from './setBilling'
 import SetConfig from './setConfig'
 import AddAccess from './addAccess'
 import DisableAccessCheck from './disableAccessCheck'
 
-export const executeCommands = [Deploy, AddAccess, DisableAccessCheck, SetBilling, SetConfig]
+export const executeCommands = [
+  Deploy,
+  Upgrade,
+  AddAccess,
+  DisableAccessCheck,
+  SetBilling,
+  SetConfig,
+]
 export const inspectionCommands = [inspect]

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/upgrade.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/upgrade.ts
@@ -1,0 +1,7 @@
+import { makeExecuteCommand, upgradeCommandConfig } from '@chainlink/starknet-gauntlet'
+import { CATEGORIES } from '../../lib/categories'
+import { ocr2ContractLoader } from '../../lib/contracts'
+
+export default makeExecuteCommand(
+  upgradeCommandConfig(CATEGORIES.OCR2, CATEGORIES.OCR2, ocr2ContractLoader),
+)

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/proxy/index.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/proxy/index.ts
@@ -1,7 +1,8 @@
 import Deploy from './deploy'
+import Upgrade from './upgrade'
 import Inspect from './inspection/inspect'
 import ProposeAggregator from './proposeAggregator'
 import ConfirmAggregator from './confirmAggregator'
 
-export const executeCommands = [Deploy, ProposeAggregator, ConfirmAggregator]
+export const executeCommands = [Deploy, Upgrade, ProposeAggregator, ConfirmAggregator]
 export const inspectionCommands = [Inspect]

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/proxy/upgrade.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/proxy/upgrade.ts
@@ -1,0 +1,7 @@
+import { makeExecuteCommand, upgradeCommandConfig } from '@chainlink/starknet-gauntlet'
+import { CATEGORIES } from '../../lib/categories'
+import { ocr2ProxyLoader } from '../../lib/contracts'
+
+export default makeExecuteCommand(
+  upgradeCommandConfig(CATEGORIES.PROXY, CATEGORIES.PROXY, ocr2ProxyLoader),
+)

--- a/packages-ts/starknet-gauntlet-token/README.md
+++ b/packages-ts/starknet-gauntlet-token/README.md
@@ -29,3 +29,10 @@ yarn gauntlet token:transfer --network=<NETWORK> --recipient=<RECPIENT_ACCOUNT> 
 ```bash
 yarn gauntlet token:balance_of --network=<NETWORK> --address=<ACCOUNT_ADDRESS> <TOKEN_CONTRACT_ADDRESS>
 ```
+
+### Upgrade
+
+```bash
+yarn gauntlet token:upgrade --network=<NETWORK> --classHash=<CLASS_HASH> <TOKEN_CONTRACT_ADDRESS>
+```
+

--- a/packages-ts/starknet-gauntlet-token/src/commands/token/index.ts
+++ b/packages-ts/starknet-gauntlet-token/src/commands/token/index.ts
@@ -1,5 +1,6 @@
 import Deploy from './deploy'
+import Upgrade from './upgrade'
 import Mint from './mint'
 import Transfer from './transfer'
 
-export default [Deploy, Mint, Transfer]
+export default [Deploy, Mint, Transfer, Upgrade]

--- a/packages-ts/starknet-gauntlet-token/src/commands/token/upgrade.ts
+++ b/packages-ts/starknet-gauntlet-token/src/commands/token/upgrade.ts
@@ -1,0 +1,7 @@
+import { makeExecuteCommand, upgradeCommandConfig } from '@chainlink/starknet-gauntlet'
+import { CATEGORIES } from '../../lib/categories'
+import { tokenContractLoader } from '../../lib/contracts'
+
+export default makeExecuteCommand(
+  upgradeCommandConfig(CATEGORIES.TOKEN, CATEGORIES.TOKEN, tokenContractLoader),
+)

--- a/packages-ts/starknet-gauntlet/src/commands/base/index.ts
+++ b/packages-ts/starknet-gauntlet/src/commands/base/index.ts
@@ -1,3 +1,4 @@
 export * from './command'
 export * from './executeCommand'
 export * from './inspectionCommand'
+export * from './upgradeCommandConfig'

--- a/packages-ts/starknet-gauntlet/src/commands/base/upgradeCommandConfig.ts
+++ b/packages-ts/starknet-gauntlet/src/commands/base/upgradeCommandConfig.ts
@@ -1,0 +1,46 @@
+import { isValidAddress } from '../../utils'
+import { ExecuteCommandConfig } from '.'
+
+type ContractInput = [classHash: string]
+
+export interface UserInput {
+  classHash: string
+}
+
+const validateClassHash = async (input) => {
+  if (isValidAddress(input.classHash)) {
+    return true
+  }
+  throw new Error(`Invalid Class Hash: ${input.classHash}`)
+}
+
+const makeUserInput = async (flags): Promise<UserInput> => {
+  if (flags.input) return flags.input as UserInput
+  return {
+    classHash: flags.classHash,
+  }
+}
+
+const makeContractInput = async (input: UserInput): Promise<ContractInput> => {
+  return [input.classHash]
+}
+
+export const upgradeCommandConfig = (
+  contractId: string,
+  category: string,
+  contractLoader: any,
+): ExecuteCommandConfig<UserInput, ContractInput> => ({
+  contractId,
+  category: contractId,
+  action: 'upgrade',
+  ux: {
+    description: 'Upgrades contract to new class hash',
+    examples: [
+      `${contractId}:upgrade --network=<NETWORK> --classHash=<CLASS_HASH> <CONTRACT_ADDRESS>`,
+    ],
+  },
+  makeUserInput,
+  makeContractInput,
+  validations: [validateClassHash],
+  loadContract: contractLoader,
+})


### PR DESCRIPTION
Once a contract has been declared via https://github.com/smartcontractkit/chainlink-starknet/pull/296 any user can pass in the classHash to the upgrade command.

Because the upgrade abi is the same for all contracts I created a utility function to create the execution command config