### PR TITLE
Add libfunc validation

### DIFF
--- a/.github/actions/install-cairo/action.yml
+++ b/.github/actions/install-cairo/action.yml
@@ -8,7 +8,7 @@ inputs:
     required: false
   scarb_version:
     description: Scarb release version
-    default: "v0.3.0"
+    default: "v0.4.0"
     required: false
 
 runs:

--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -21,3 +21,10 @@ casm = true
 # pythonic hints are necessary for cairo-lang to parse the casm file:
 # Unsupported compiled class format. Cairo 1.0 compiled class must contain the attribute `pythonic_hints`.
 casm-add-pythonic-hints = true
+
+# this elevants the severity of disallowed libfuncs to compilation errors
+# https://docs.swmansion.com/scarb/docs/starknet/contract-target#allowed-libfuncs-validation
+allowed-libfuncs-deny = true
+
+# TODO: change the allowlist to 'audited' when cairo v2 is released
+allowed-libfuncs-list.name = "experimental_v0.1.0"


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCI-1424

Note: this uses Scarb v0.4.0 (Cairo v1.1.0), however, there is no way to specify the Scarb version in the toml config file. The Scarb version is only defined in the CI.

For the latest Cairo version running on testnet (v1.1.0), we currently use some disallowed Sierra libfuncs in our contracts, namely `upcast`, `downcast`, `ec_point_from_x_nz`. These libfuncs are missing from the current testnet allowlist but are in the audited allowlist in the latest Cairo release candidate v2.0.0-rc2. 

This means that our Starknet contracts are not deployable until Cairo v2 is released, and a todo has been left to update the allowlist being used after the Cairo v2 release