### PR TITLE
BCF-2440: rm chainset

### DIFF
--- a/relayer/pkg/chainlink/chain/chain.go
+++ b/relayer/pkg/chainlink/chain/chain.go
@@ -11,8 +11,6 @@ import (
 	_ "github.com/btcsuite/btcd/chaincfg/chainhash"
 )
 
-type ChainSet = types.ChainSet[string, Chain]
-
 type Chain interface {
 	types.ChainService
 


### PR DESCRIPTION
The corresponding change in core deleted all ChainSet references. We can remove this now