### PR TITLE
nix golang linter build use go1.21 (previously using go1.20)

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -20,7 +20,7 @@
     go_1_21
     gopls
     delve
-    golangci-lint
+    (golangci-lint.override { buildGoModule = buildGo121Module; })
     gotools
 
     kube3d


### PR DESCRIPTION
related: https://github.com/golangci/golangci-lint/pull/3922#issuecomment-1680420005
(tldr: golangci-lint depends on the version of go it is compiled with - the default nixpkgs build is only 1.20)