### PR TITLE
gauntlet: use v3 transactions

### DIFF
--- a/packages-ts/starknet-gauntlet/src/provider/index.ts
+++ b/packages-ts/starknet-gauntlet/src/provider/index.ts
@@ -35,7 +35,7 @@ interface IProvider<P> {
   signAndSend: (calls: Call[], wait?: boolean) => Promise<TransactionResponse>
 }
 
-export interface IStarknetProvider extends IProvider<StarknetProvider> { }
+export interface IStarknetProvider extends IProvider<StarknetProvider> {}
 export const makeProvider = (
   url: string,
   wallet?: IStarknetWallet,

--- a/packages-ts/starknet-gauntlet/src/provider/index.ts
+++ b/packages-ts/starknet-gauntlet/src/provider/index.ts
@@ -6,6 +6,7 @@ import {
   CompiledContract,
   Account,
   Call,
+  constants,
 } from 'starknet'
 import { IStarknetWallet } from '../wallet'
 
@@ -34,7 +35,7 @@ interface IProvider<P> {
   signAndSend: (calls: Call[], wait?: boolean) => Promise<TransactionResponse>
 }
 
-export interface IStarknetProvider extends IProvider<StarknetProvider> {}
+export interface IStarknetProvider extends IProvider<StarknetProvider> { }
 export const makeProvider = (
   url: string,
   wallet?: IStarknetWallet,
@@ -80,12 +81,24 @@ class Provider implements IStarknetProvider {
   constructor(nodeUrl: string, wallet?: IStarknetWallet) {
     this.provider = new StarknetProvider({ nodeUrl })
     if (wallet) {
-      this.account = new Account(this.provider, wallet.getAccountAddress(), wallet.signer)
+      this.account = new Account(
+        this.provider,
+        wallet.getAccountAddress(),
+        wallet.signer,
+        /* cairoVersion= */ null, // don't set cairo version so that it's automatically detected from the contract
+        /* transactionVersion= */ constants.TRANSACTION_VERSION.V3,
+      )
     }
   }
 
   setAccount(wallet: IStarknetWallet) {
-    this.account = new Account(this.provider, wallet.getAccountAddress(), wallet.signer)
+    this.account = new Account(
+      this.provider,
+      wallet.getAccountAddress(),
+      wallet.signer,
+      /* cairoVersion= */ null,
+      /* transactionVersion= */ constants.TRANSACTION_VERSION.V3,
+    )
   }
 
   send = async () => {


### PR DESCRIPTION
local integration tests pass, and confirmed that the fee is now paid in FRI:

```
...
{"level":"info","stdout":"  type: 'DEPLOY',\n","time":"2024-03-05T01:16:14-05:00","message":"gauntlet"}                                                                                
{"level":"info","stdout":"  transaction_hash: '0x7cfb8445c9c743aa0b24c41d169ee13ed3e58d1e949149896aa9fa0a3dea818',\n","time":"2024-03-05T01:16:14-05:00","message":"gauntlet"}         
{"level":"info","stdout":"  actual_fee: { unit: 'FRI', amount: '0x1a9a' },\n","time":"2024-03-05T01:16:14-05:00","message":"gauntlet"}     
...
```
