### PR TITLE
gauntlet: add DEPLOY_ACCOUNT action

### DIFF
--- a/packages-ts/starknet-gauntlet-multisig/src/wrapper/index.ts
+++ b/packages-ts/starknet-gauntlet-multisig/src/wrapper/index.ts
@@ -91,6 +91,8 @@ export const wrapCommand = <UI, CI>(
       c.executionContext = {
         provider: c.provider,
         wallet: c.wallet,
+        category: registeredCommand.id,
+        action: 'multisig',
         id,
         contractAddress: c.contractAddress,
         flags: flags,

--- a/packages-ts/starknet-gauntlet-oz/src/commands/account/deploy.ts
+++ b/packages-ts/starknet-gauntlet-oz/src/commands/account/deploy.ts
@@ -34,10 +34,22 @@ const makeUserInput = async (flags, _, env): Promise<UserInput> => {
   }
 }
 
-const validateClassHash = async (input) => {
-  if (isValidAddress(input.classHash) || input.classHash === undefined) {
+const validateClassHash = async (input, executionContext) => {
+  if (isValidAddress(input.classHash)) {
     return true
   }
+
+  if (input.classHash === undefined) {
+    // declaring the contract will happen automatically as part of our regular deploy action, but
+    // deploying account contracts for a new account require an already declared account contract,
+    // which has to be done from a funded account.
+    // ref: https://book.starknet.io/ch04-03-deploy-hello-account.html#declaring-the-account-contract
+    if (executionContext.action === 'deploy-account') {
+      throw new Error('Account contract has to be declared for a DEPLOY_ACCOUNT action')
+    }
+    return true
+  }
+
   throw new Error(`Invalid Class Hash: ${input.classHash}`)
 }
 

--- a/packages-ts/starknet-gauntlet-oz/src/commands/account/deploy.ts
+++ b/packages-ts/starknet-gauntlet-oz/src/commands/account/deploy.ts
@@ -25,7 +25,7 @@ const makeUserInput = async (flags, _, env): Promise<UserInput> => {
   const keypair = ec.starkCurve.utils.randomPrivateKey()
   const generatedPK = '0x' + Buffer.from(keypair).toString('hex')
   const pubkey = flags.publicKey || env.publicKey || ec.starkCurve.getStarkKey(keypair)
-  const salt: number = flags.salt ? +flags.salt : undefined
+  const salt: number = !isNaN(flags.salt) ? +flags.salt : undefined
   return {
     publicKey: pubkey,
     privateKey: (!flags.publicKey || !env.account) && generatedPK,
@@ -64,7 +64,7 @@ const beforeExecute: BeforeExecute<UserInput, ContractInput> = (
 ) => async () => {
   deps.logger.info(`About to deploy an OZ 0.x Account Contract with:
     public key: ${input.contract[0]}
-    salt: ${input.user.salt || 'randomly generated'}
+    salt: ${!isNaN(input.user.salt) ? input.user.salt : 'randomly generated'}
     action: ${context.action}`)
   if (input.user.privateKey) {
     await deps.prompt(`The generated private key will be shown next, continue?`)

--- a/packages-ts/starknet-gauntlet-oz/src/commands/account/deploy.ts
+++ b/packages-ts/starknet-gauntlet-oz/src/commands/account/deploy.ts
@@ -79,12 +79,12 @@ const afterExecute: AfterExecute<UserInput, ContractInput> = (context, input, de
   }
 }
 
-const commandConfig: ExecuteCommandConfig<UserInput, ContractInput> = {
+const deployCommandConfig: ExecuteCommandConfig<UserInput, ContractInput> = {
   contractId: CONTRACT_LIST.ACCOUNT,
   category: CATEGORIES.ACCOUNT,
   action: 'deploy',
   ux: {
-    description: 'Deploys an OpenZeppelin Account contract',
+    description: 'Deploys an OpenZeppelin Account contract from an existing account',
     examples: [
       `${CATEGORIES.ACCOUNT}:deploy --network=<NETWORK> --address=<ADDRESS> --classHash=<CLASS_HASH> <CONTRACT_ADDRESS>`,
     ],
@@ -99,4 +99,21 @@ const commandConfig: ExecuteCommandConfig<UserInput, ContractInput> = {
   },
 }
 
-export default makeExecuteCommand(commandConfig)
+const deployAccountCommandConfig: ExecuteCommandConfig<UserInput, ContractInput> = Object.assign(
+  {},
+  deployCommandConfig,
+  {
+    action: 'deploy-account',
+    ux: {
+      description: 'Deploys an OpenZeppelin Account contract using DEPLOY_ACCOUNT',
+      examples: [
+        `${CATEGORIES.ACCOUNT}:deploy-account --network=<NETWORK> --address=<ADDRESS> --classHash=<CLASS_HASH> <CONTRACT_ADDRESS>`,
+      ],
+    },
+  },
+)
+
+const Deploy = makeExecuteCommand(deployCommandConfig)
+const DeployAccount = makeExecuteCommand(deployAccountCommandConfig)
+
+export { Deploy, DeployAccount }

--- a/packages-ts/starknet-gauntlet-oz/src/commands/account/deploy.ts
+++ b/packages-ts/starknet-gauntlet-oz/src/commands/account/deploy.ts
@@ -52,7 +52,8 @@ const beforeExecute: BeforeExecute<UserInput, ContractInput> = (
 ) => async () => {
   deps.logger.info(`About to deploy an OZ 0.x Account Contract with:
     public key: ${input.contract[0]}
-    salt: ${input.user.salt || 'randomly generated'}`)
+    salt: ${input.user.salt || 'randomly generated'}
+    action: ${context.action}`)
   if (input.user.privateKey) {
     await deps.prompt(`The generated private key will be shown next, continue?`)
     deps.logger.line()

--- a/packages-ts/starknet-gauntlet-oz/src/commands/account/index.ts
+++ b/packages-ts/starknet-gauntlet-oz/src/commands/account/index.ts
@@ -1,3 +1,3 @@
-import Deploy from './deploy'
+import { Deploy, DeployAccount } from './deploy'
 import Declare from './declare'
-export default [Deploy, Declare]
+export default [Deploy, DeployAccount, Declare]

--- a/packages-ts/starknet-gauntlet-oz/test/commands/account.test.ts
+++ b/packages-ts/starknet-gauntlet-oz/test/commands/account.test.ts
@@ -1,5 +1,5 @@
 import { makeProvider } from '@chainlink/starknet-gauntlet'
-import deployCommand from '../../src/commands/account/deploy'
+import { Deploy } from '../../src/commands/account/deploy'
 import { registerExecuteCommand, TIMEOUT, LOCAL_URL } from '@chainlink/starknet-gauntlet/test/utils'
 import { accountContractLoader } from '../../src/lib/contracts'
 import { Contract } from 'starknet'
@@ -11,7 +11,7 @@ describe('OZ Account Contract', () => {
   it(
     'Deployment',
     async () => {
-      const command = await registerExecuteCommand(deployCommand).create({}, [])
+      const command = await registerExecuteCommand(Deploy).create({}, [])
 
       const report = await command.execute()
       expect(report.responses[0].tx.status).toEqual('ACCEPTED')

--- a/packages-ts/starknet-gauntlet-token/test/commands/token.test.ts
+++ b/packages-ts/starknet-gauntlet-token/test/commands/token.test.ts
@@ -1,4 +1,4 @@
-import deployOZCommand from '@chainlink/starknet-gauntlet-oz/src/commands/account/deploy'
+import { Deploy as deployOZCommand } from '@chainlink/starknet-gauntlet-oz/src/commands/account/deploy'
 import deployTokenCommand from '../../src/commands/token/deploy'
 import mintTokensCommand from '../../src/commands/token/mint'
 import transferTokensCommand from '../../src/commands/token/transfer'

--- a/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
+++ b/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
@@ -16,6 +16,8 @@ import { IStarknetWallet } from '../../wallet'
 import { makeCommandId, Validation, Input } from './command'
 
 export interface ExecutionContext {
+  category: string
+  action: string
   id: string
   contractAddress: string
   wallet: IStarknetWallet
@@ -112,6 +114,8 @@ export const makeExecuteCommand = <UI, CI>(config: ExecuteCommandConfig<UI, CI>)
       }
 
       c.executionContext = {
+        category: config.category,
+        action: config.action,
         provider: c.provider,
         wallet: c.wallet,
         id: makeCommandId(config.category, config.action, config.suffixes),

--- a/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
+++ b/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
@@ -272,12 +272,25 @@ export const makeExecuteCommand = <UI, CI>(config: ExecuteCommandConfig<UI, CI>)
 
       // classHash has to be provided, we can't declare on new accounts.
       const classHash: string = this.input?.user?.['classHash']
+      const salt = this.input?.user?.['salt']
+      const contractInput = this.input.contract as any
+
+      const newAccountAddress = hash.calculateContractAddressFromHash(
+        salt,
+        classHash,
+        contractInput,
+        0,
+      )
+      deps.logger.info(
+        `Add funds to pay for deploy fees to the account address: ${newAccountAddress}`,
+      )
+      await deps.prompt('Funded?')
 
       const tx: TransactionResponse = await this.provider.deployAccountContract(
         classHash,
         this.input.contract,
         false,
-        this.input?.user?.['salt'],
+        salt,
       )
 
       if (tx.hash === undefined) {

--- a/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
+++ b/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
@@ -270,21 +270,10 @@ export const makeExecuteCommand = <UI, CI>(config: ExecuteCommandConfig<UI, CI>)
       await deps.prompt('Continue?')
       deps.logger.loading(`Sending transaction...`)
 
-      // if "--classHash" is not included, declare before deploying
-      let classHash: string | undefined = this.input?.user?.['classHash']
+      // classHash has to be provided, we can't declare on new accounts.
+      const classHash: string = this.input?.user?.['classHash']
 
-      let tx: TransactionResponse
-
-      if (classHash === undefined) {
-        tx = await this.provider.declareContract(this.contract, this.compiledContractHash, false)
-        const declaredTx = tx.tx as DeclareContractResponse
-        classHash = declaredTx?.class_hash
-        if (!classHash) {
-          deps.logger.error(`Failed to declare contract:\n${JSON.stringify(tx, null, 2)}`)
-          return tx
-        }
-      }
-      tx = await this.provider.deployAccountContract(
+      const tx: TransactionResponse = await this.provider.deployAccountContract(
         classHash,
         this.input.contract,
         false,

--- a/packages-ts/starknet-gauntlet/src/provider/index.ts
+++ b/packages-ts/starknet-gauntlet/src/provider/index.ts
@@ -128,7 +128,7 @@ class Provider implements IStarknetProvider {
     const tx = await this.account.declareAndDeploy({
       contract,
       compiledClassHash,
-      salt: salt ? '0x' + salt.toString(16) : salt, // convert number to hex or leave undefined
+      salt: !isNaN(salt) ? '0x' + salt.toString(16) : salt, // convert number to hex or leave undefined
       // unique: false,
       ...(!!input && input.length > 0 && { constructorCalldata: input }),
     })
@@ -162,7 +162,7 @@ class Provider implements IStarknetProvider {
   deployContract = async (classHash: string, input: any = [], wait = true, salt = undefined) => {
     const tx = await this.account.deployContract({
       classHash: classHash,
-      salt: salt ? '0x' + salt.toString(16) : salt,
+      salt: !isNaN(salt) ? '0x' + salt.toString(16) : salt,
       ...(!!input && input.length > 0 && { constructorCalldata: input }),
     })
     const response = wrapResponse(this, tx)

--- a/packages-ts/starknet-gauntlet/src/provider/index.ts
+++ b/packages-ts/starknet-gauntlet/src/provider/index.ts
@@ -1,6 +1,7 @@
 import { TransactionResponse } from '../transaction'
 import {
   RpcProvider as StarknetProvider,
+  DeclareContractResponse,
   InvokeFunctionResponse,
   DeployContractResponse,
   CompiledContract,
@@ -45,7 +46,7 @@ export const makeProvider = (
 
 export const wrapResponse = (
   provider: IStarknetProvider,
-  response: InvokeFunctionResponse | DeployContractResponse,
+  response: InvokeFunctionResponse | DeployContractResponse | DeclareContractResponse,
   address?: string,
 ): TransactionResponse => {
   const txResponse: TransactionResponse = {

--- a/packages-ts/starknet-gauntlet/src/provider/index.ts
+++ b/packages-ts/starknet-gauntlet/src/provider/index.ts
@@ -28,6 +28,12 @@ interface IProvider<P> {
     wait?: boolean,
     salt?: number,
   ) => Promise<TransactionResponse>
+  deployAccountContract: (
+    classHash: string,
+    input: any,
+    wait?: boolean,
+    salt?: number,
+  ) => Promise<TransactionResponse>
   declareContract: (
     contract: CompiledContract,
     compiledClassHash?: string,
@@ -158,6 +164,23 @@ class Provider implements IStarknetProvider {
       classHash: classHash,
       salt: salt ? '0x' + salt.toString(16) : salt,
       ...(!!input && input.length > 0 && { constructorCalldata: input }),
+    })
+    const response = wrapResponse(this, tx)
+
+    if (!wait) return response
+    await response.wait()
+    return response
+  }
+
+  /**
+   * Deploys an account contract using DEPLOY_ACCOUNT given a class hash
+   */
+
+  deployAccountContract = async (classHash: string, input: any = [], wait = true, salt = 0) => {
+    const tx = await this.account.deployAccount({
+      classHash: classHash,
+      constructorCalldata: input,
+      addressSalt: '0x' + salt.toString(16),
     })
     const response = wrapResponse(this, tx)
 

--- a/packages-ts/starknet-gauntlet/src/transaction/index.ts
+++ b/packages-ts/starknet-gauntlet/src/transaction/index.ts
@@ -1,10 +1,15 @@
-import { InvokeFunctionResponse, RPC } from 'starknet'
+import {
+  InvokeFunctionResponse,
+  DeclareContractResponse,
+  DeployContractResponse,
+  RPC,
+} from 'starknet'
 
 export type TransactionResponse = {
   hash: string
   address?: string
   wait: () => Promise<{ success: boolean }>
-  tx?: InvokeFunctionResponse
+  tx?: InvokeFunctionResponse | DeclareContractResponse | DeployContractResponse
   code?: RPC.SPEC.TXN_STATUS
   status: 'PENDING' | 'ACCEPTED' | 'REJECTED'
   errorMessage?: string


### PR DESCRIPTION
```
🧤  gauntlet 0.3.1                                                                                                                                                                                                      
ℹ️   About to deploy an OZ 0.x Account Contract with:                                                                                                                                                                   
    public key: 0x39d9e6ce352ad4530a0ef5d5a18fd3303c3606a7fa6ac5b620020ad681cc33b                                                                                                                                       
    salt: 0                                                                                                                                                                                                             
    action: deploy-account                                                                                                                                                                                              
ℹ️   Deploying account contract account                                                                                                                                                                                 
🤔  Continue? (Y / N)y                                                                                                                                                                                                  
⏳  Sending transaction...                                                                                                                                                                                              
ℹ️  "Add funds to pay for deploy fees to the account address: 0x76d88e9ffcfba5d6fa483069bff75dba220ec4f4361b96acc480eccea6fd4b8
🤔  Funded? (Y / N)y                                                                                                                                                                                                    
(node:488049) ExperimentalWarning: The Fetch API is an experimental feature. This feature could change at any time                                                                                                      
(Use `node --trace-warnings ...` to show where the warning was created)                                                                                                                                                 
⏳  Waiting for tx confirmation at 0x5bbc200f532556cdf2f9adfc3635f50a6557685170aa8b684a00c26b1abaad7...                                                                                                                 
✅  Contract deployed on 0x5bbc200f532556cdf2f9adfc3635f50a6557685170aa8b684a00c26b1abaad7 with address 0x76d88e9ffcfba5d6fa483069bff75dba220ec4f4361b96acc480eccea6fd4b8  
```
