### PR TITLE
[BCI-2623]: removes hardcoded accounts from `packages-ts/`

### DIFF
--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -11,4 +11,4 @@ dependencies = [
 [[package]]
 name = "openzeppelin"
 version = "0.9.0"
-source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.9.0#861fc416f87addbe23a3b47f9d19ab27c10d5dc8"
+source = "git+https://github.com/OpenZeppelin/cairo-contracts.git?tag=v0.9.0#364db5b1aecc1335d2e65db887291d19aa28937d"

--- a/packages-ts/starknet-gauntlet-multisig/src/wrapper/index.ts
+++ b/packages-ts/starknet-gauntlet-multisig/src/wrapper/index.ts
@@ -75,7 +75,7 @@ export const wrapCommand = <UI, CI>(
     static create = async (flags, args) => {
       const c = new MsigCommand(flags, args)
 
-      const env = deps.makeEnv(flags)
+      const env = await deps.makeEnv(flags)
 
       c.wallet = await deps.makeWallet(env)
       c.provider = deps.makeProvider(env.providerUrl, c.wallet)
@@ -269,7 +269,7 @@ export const wrapCommand = <UI, CI>(
         deps.logger.success(`Tx executed at ${tx.hash}`)
       }
 
-      let result = {
+      const result = {
         responses: [
           {
             tx,
@@ -288,7 +288,7 @@ export const wrapCommand = <UI, CI>(
 
       const data = await this.afterExecute(result, proposalId)
 
-      return !!data ? { ...result, data: { ...data } } : result
+      return data ? { ...result, data: { ...data } } : result
     }
   }
 

--- a/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
@@ -7,13 +7,12 @@ import {
   registerExecuteCommand,
   TIMEOUT,
   LOCAL_URL,
-  devnetAccount0Address,
+  StarknetAccount,
+  fetchAccount,
 } from '@chainlink/starknet-gauntlet/test/utils'
 import { loadContract } from '@chainlink/starknet-gauntlet'
 import { CONTRACT_LIST } from '../../src/lib/contracts'
 import { Contract, InvokeTransactionReceiptResponse } from 'starknet'
-
-let account = devnetAccount0Address
 
 const signers = [
   'ocr2on_starknet_04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603730', // ocr2on_starknet_<key>
@@ -73,8 +72,13 @@ const validInput = {
 }
 
 describe('OCR2 Contract', () => {
+  let account: StarknetAccount
   let contractAddress: string
   let accessController: string
+
+  beforeAll(async () => {
+    account = await fetchAccount()
+  })
 
   it(
     'Deploy AC',
@@ -95,7 +99,7 @@ describe('OCR2 Contract', () => {
       const command = await registerExecuteCommand(deployCommand).create(
         {
           input: {
-            owner: account,
+            owner: account.address,
             maxAnswer: 10000,
             minAnswer: 1,
             decimals: 18,
@@ -174,7 +178,7 @@ describe('OCR2 Contract', () => {
       // TODO: use StarknetContract decodeEvents from starknet-hardhat-plugin instead
       const eventData = receipt.events[0].data
       // reconstruct signers array from event
-      let eventSigners: bigint[] = []
+      const eventSigners: bigint[] = []
       for (let i = 0; i < signers.length; i++) {
         const signer = BigInt(eventData[4 + 2 * i]) // split according to event structure
         eventSigners.push(signer)

--- a/packages-ts/starknet-gauntlet-ocr2/test/commands/proxy.test.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/test/commands/proxy.test.ts
@@ -4,17 +4,21 @@ import deployProxyCommand from '../../src/commands/proxy/deploy'
 import proposeAggregatorCommand from '../../src/commands/proxy/proposeAggregator'
 import confirmAggregatorCommand from '../../src/commands/proxy/confirmAggregator'
 import {
+  StarknetAccount,
+  fetchAccount,
   registerExecuteCommand,
   TIMEOUT,
-  devnetAccount0Address,
 } from '@chainlink/starknet-gauntlet/test/utils'
 
-let account = devnetAccount0Address
-
 describe('Proxy Contract', () => {
+  let account: StarknetAccount
   let contractAddress: string
   let accessController: string
   let proxy: string
+
+  beforeAll(async () => {
+    account = await fetchAccount()
+  })
 
   it(
     'Deploy AC',
@@ -35,7 +39,7 @@ describe('Proxy Contract', () => {
       const command = await registerExecuteCommand(deployOCR2Command).create(
         {
           input: {
-            owner: account,
+            owner: account.address,
             maxAnswer: 10000,
             minAnswer: 1,
             decimals: 18,
@@ -60,7 +64,7 @@ describe('Proxy Contract', () => {
       const command = await registerExecuteCommand(deployProxyCommand).create(
         {
           input: {
-            owner: account,
+            owner: account.address,
             address: contractAddress,
           },
         },
@@ -80,7 +84,7 @@ describe('Proxy Contract', () => {
       const command = await registerExecuteCommand(proposeAggregatorCommand).create(
         {
           input: {
-            owner: account,
+            owner: account.address,
             address: contractAddress,
           },
         },
@@ -99,7 +103,7 @@ describe('Proxy Contract', () => {
       const command = await registerExecuteCommand(confirmAggregatorCommand).create(
         {
           input: {
-            owner: account,
+            owner: account.address,
             address: contractAddress,
           },
         },

--- a/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
+++ b/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
@@ -98,7 +98,7 @@ export const makeExecuteCommand = <UI, CI>(config: ExecuteCommandConfig<UI, CI>)
     static create = async (flags, args) => {
       const c = new ExecuteCommand(flags, args)
 
-      const env = deps.makeEnv(flags)
+      const env = await deps.makeEnv(flags)
 
       c.wallet = await deps.makeWallet(env)
       c.provider = deps.makeProvider(env.providerUrl, c.wallet)
@@ -291,7 +291,7 @@ export const makeExecuteCommand = <UI, CI>(config: ExecuteCommandConfig<UI, CI>)
         tx = await this.executeWithSigner()
       }
 
-      let result = {
+      const result = {
         responses: [
           {
             tx,
@@ -301,7 +301,7 @@ export const makeExecuteCommand = <UI, CI>(config: ExecuteCommandConfig<UI, CI>)
       }
       const data = await this.afterExecute(result)
 
-      return !!data ? { ...result, data: { ...data } } : result
+      return data ? { ...result, data: { ...data } } : result
     }
   }
 

--- a/packages-ts/starknet-gauntlet/src/commands/base/inspectionCommand.ts
+++ b/packages-ts/starknet-gauntlet/src/commands/base/inspectionCommand.ts
@@ -88,7 +88,7 @@ export const makeInspectionCommand = <UI, CI, CompareInput, QueryResult>(
     static create = async (flags, args) => {
       const c = new InspectionCommand(flags, args)
 
-      const env = deps.makeEnv(flags)
+      const env = await deps.makeEnv(flags)
 
       c.provider = deps.makeProvider(env.providerUrl)
       c.contractAddress = args[0]

--- a/packages-ts/starknet-gauntlet/src/dependencies/index.ts
+++ b/packages-ts/starknet-gauntlet/src/dependencies/index.ts
@@ -1,7 +1,6 @@
 import { logger, prompt } from '@chainlink/gauntlet-core/dist/utils'
 import { IStarknetProvider } from '../provider'
 import { IStarknetWallet } from '../wallet'
-import { makeProvider } from '@chainlink/evm-gauntlet'
 
 export interface Env {
   providerUrl: string
@@ -16,7 +15,7 @@ export interface Env {
 export interface Dependencies {
   logger: typeof logger
   prompt: typeof prompt
-  makeEnv: (flags: Record<string, string | boolean>) => Env
+  makeEnv: (flags: Record<string, string | boolean>) => Promise<Env> | Env
   makeProvider: (url: string, wallet?: IStarknetWallet) => IStarknetProvider
   makeWallet: (env: Env) => Promise<IStarknetWallet>
 }

--- a/packages-ts/starknet-gauntlet/test/commands/execute.test.ts
+++ b/packages-ts/starknet-gauntlet/test/commands/execute.test.ts
@@ -1,14 +1,5 @@
+import { loadExampleContract, registerExecuteCommand, TIMEOUT } from '../utils'
 import { ExecuteCommandConfig, makeExecuteCommand } from '../../src/index'
-import {
-  devnetAccount0Address,
-  devnetPrivateKey,
-  loadExampleContract,
-  registerExecuteCommand,
-  TIMEOUT,
-} from '../utils'
-
-let account: string = devnetAccount0Address
-let privateKey: string = devnetPrivateKey
 
 describe('Execute Command', () => {
   type UserInput = {
@@ -18,7 +9,7 @@ describe('Execute Command', () => {
 
   type ContractInput = [string, number]
 
-  const makeUserInput = async (flags, args): Promise<UserInput> => {
+  const makeUserInput = async (flags): Promise<UserInput> => {
     return {
       a: flags.a,
       b: Number(flags.b),
@@ -64,20 +55,18 @@ describe('Execute Command', () => {
 })
 
 describe('Execute with network', () => {
-  let contractAddress: string
-
   it(
     'Command deploy execution',
     async () => {
-      const makeUserInput = async (flags, args) => {
+      const makeUserInput = async () => {
         return
       }
 
-      const makeContractInput = async (userInput) => {
+      const makeContractInput = async () => {
         return {}
       }
 
-      const deployCommandConfig: ExecuteCommandConfig<any, any> = {
+      const deployCommandConfig: ExecuteCommandConfig<unknown, unknown> = {
         contractId: '',
         category: 'example',
         action: 'deploy',
@@ -96,8 +85,6 @@ describe('Execute with network', () => {
       const commandInstance = await command.create({}, [])
       const report = await commandInstance.execute()
       expect(report.responses[0].tx.status).toEqual('ACCEPTED')
-
-      contractAddress = report.responses[0].contract
     },
     TIMEOUT,
   )


### PR DESCRIPTION
Please see [this](https://smartcontract-it.atlassian.net/browse/BCI-2623) ticket for details

In summary:

- The hardcoded values for `devnetPrivateKey` and `devnetAccount0Address` have been removed
- A starknet test account is now retrieved from the local devnet using a simplified version of [this](https://github.com/starknet-io/starknet.js/blob/602a131d4abe05ada9c59aecf6bf165968c15c97/__tests__/jestGlobalSetup.ts#L24) function
- All references to these hardcoded values have been replaced in `packages-ts/`