### PR TITLE
Starknet Chain Client: Add Block Methods

### DIFF
--- a/relayer/pkg/chainlink/ocr2/contract_reader.go
+++ b/relayer/pkg/chainlink/ocr2/contract_reader.go
@@ -5,8 +5,8 @@ import (
 	"math/big"
 	"time"
 
-	starknetutils "github.com/NethermindEth/starknet.go/utils"
 	"github.com/NethermindEth/juno/core/felt"
+	starknetutils "github.com/NethermindEth/starknet.go/utils"
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"

--- a/relayer/pkg/chainlink/ocr2/medianreport/report.go
+++ b/relayer/pkg/chainlink/ocr2/medianreport/report.go
@@ -8,8 +8,8 @@ import (
 
 	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/starknet"
 
-	starknetutils "github.com/NethermindEth/starknet.go/utils"
 	"github.com/NethermindEth/juno/core/felt"
+	starknetutils "github.com/NethermindEth/starknet.go/utils"
 	"github.com/pkg/errors"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"

--- a/relayer/pkg/starknet/chain_client.go
+++ b/relayer/pkg/starknet/chain_client.go
@@ -105,7 +105,15 @@ func (c *Client) ChainId(ctx context.Context) (string, error) {
 	results, err := c.Batch(ctx, NewBatchBuilder().RequestChainId())
 
 	if err != nil {
-		return "", fmt.Errorf("error in ChainId: %w", err)
+		return "", fmt.Errorf("error in ChainId : %w", err)
+	}
+
+	if len(results) != 1 {
+		return "", fmt.Errorf("unexpected result from ChainId")
+	}
+
+	if results[0].Error != nil {
+		return "", fmt.Errorf("error in ChainId result: %w", results[0].Error)
 	}
 
 	chainId, ok := results[0].Result.(*string)

--- a/relayer/pkg/starknet/chain_client.go
+++ b/relayer/pkg/starknet/chain_client.go
@@ -1,0 +1,60 @@
+package starknet
+
+import (
+	"context"
+
+	"github.com/NethermindEth/juno/core/felt"
+	starknetrpc "github.com/NethermindEth/starknet.go/rpc"
+	gethrpc "github.com/ethereum/go-ethereum/rpc"
+	"github.com/pkg/errors"
+)
+
+// type alias for readibility
+type FinalizedBlock = starknetrpc.Block
+
+// used to create batch requests
+type StarknetBatchBuilder interface {
+	RequestBlockByHash(ctx context.Context, h *felt.Felt) (*StarknetBatchBuilder, error)
+	RequestBlockByNumber(ctx context.Context, id uint64) (*StarknetBatchBuilder, error)
+	RequestLatestPendingBlock(ctx context.Context) (*StarknetBatchBuilder, error)
+	LatestBlockHashAndNumber(ctx context.Context) (*StarknetBatchBuilder, error)
+	EventsByFilter(ctx context.Context, f starknetrpc.EventFilter) (*StarknetBatchBuilder, error)
+	TxReceiptByHash(ctx context.Context, h *felt.Felt) (*StarknetBatchBuilder, error)
+}
+
+type StarknetChainClient interface {
+	// only finalized blocks have a block hashes
+	BlockByHash(ctx context.Context, h *felt.Felt) (FinalizedBlock, error)
+	// only finalized blocks have numbers
+	BlockByNumber(ctx context.Context, id uint64) (FinalizedBlock, error)
+	// only way to get the latest pending block (only 1 pending block exists at a time)
+	LatestPendingBlock(ctx context.Context) (starknetrpc.PendingBlock, error)
+	// returns block number and block has of latest finalized block
+	LatestBlockHashAndNumber(ctx context.Context) (starknetrpc.BlockHashAndNumberOutput, error)
+	// get block logs, event logs, etc.
+	EventsByFilter(ctx context.Context, f starknetrpc.EventFilter) ([]starknetrpc.EmittedEvent, error)
+	TxReceiptByHash(ctx context.Context, h *felt.Felt) (starknetrpc.TransactionReceipt, error)
+	Batch(builder *StarknetBatchBuilder) ([]gethrpc.BatchElem, error)
+}
+
+func (c *Client) BlockByHash(ctx context.Context, h *felt.Felt) (FinalizedBlock, error) {
+	if c.defaultTimeout != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.defaultTimeout)
+		defer cancel()
+	}
+
+	block, err := c.Provider.BlockWithTxs(ctx, starknetrpc.BlockID{Hash: h})
+
+	if err != nil {
+		return FinalizedBlock{}, errors.Wrap(err, "error in BlockByHash")
+	}
+
+	finalizedBlock, ok := block.(*FinalizedBlock)
+
+	if !ok {
+		return FinalizedBlock{}, errors.Errorf("expected type Finalized block but found: %T", block)
+	}
+
+	return *finalizedBlock, nil
+}

--- a/relayer/pkg/starknet/chain_client.go
+++ b/relayer/pkg/starknet/chain_client.go
@@ -2,11 +2,11 @@ package starknet
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/NethermindEth/juno/core/felt"
 	starknetrpc "github.com/NethermindEth/starknet.go/rpc"
 	gethrpc "github.com/ethereum/go-ethereum/rpc"
-	"github.com/pkg/errors"
 )
 
 // type alias for readibility
@@ -47,13 +47,13 @@ func (c *Client) BlockByHash(ctx context.Context, h *felt.Felt) (FinalizedBlock,
 	block, err := c.Provider.BlockWithTxs(ctx, starknetrpc.BlockID{Hash: h})
 
 	if err != nil {
-		return FinalizedBlock{}, errors.Wrap(err, "error in BlockByHash")
+		return FinalizedBlock{}, fmt.Errorf("error in BlockByHash: %w", err)
 	}
 
 	finalizedBlock, ok := block.(*FinalizedBlock)
 
 	if !ok {
-		return FinalizedBlock{}, errors.Errorf("expected type Finalized block but found: %T", block)
+		return FinalizedBlock{}, fmt.Errorf("expected type Finalized block but found: %T", block)
 	}
 
 	return *finalizedBlock, nil

--- a/relayer/pkg/starknet/chain_client.go
+++ b/relayer/pkg/starknet/chain_client.go
@@ -14,10 +14,10 @@ type FinalizedBlock = starknetrpc.Block
 
 // used to create batch requests
 type StarknetBatchBuilder interface {
-	RequestBlockByHash(h *felt.Felt) (StarknetBatchBuilder, error)
+	RequestBlockByHash(h *felt.Felt) StarknetBatchBuilder
 	// RequestBlockByNumber(id uint64) (StarknetBatchBuilder, error)
 	// RequestLatestPendingBlock() (StarknetBatchBuilder, error)
-	// RequestLatestBlockHashAndNumber() (StarknetBatchBuilder, error)
+	RequestLatestBlockHashAndNumber() StarknetBatchBuilder
 	// RequestEventsByFilter(f starknetrpc.EventFilter) (StarknetBatchBuilder, error)
 	// RequestTxReceiptByHash(h *felt.Felt) (StarknetBatchBuilder, error)
 	Build() []gethrpc.BatchElem
@@ -31,11 +31,11 @@ type batchBuilder struct {
 
 func NewBatchBuilder() StarknetBatchBuilder {
 	return &batchBuilder{
-		args: make([]gethrpc.BatchElem, 0),
+		args: nil,
 	}
 }
 
-func (b *batchBuilder) RequestBlockByHash(h *felt.Felt) (StarknetBatchBuilder, error) {
+func (b *batchBuilder) RequestBlockByHash(h *felt.Felt) StarknetBatchBuilder {
 	b.args = append(b.args, gethrpc.BatchElem{
 		Method: "starknet_getBlockWithTxs",
 		Args: []interface{}{
@@ -43,7 +43,16 @@ func (b *batchBuilder) RequestBlockByHash(h *felt.Felt) (StarknetBatchBuilder, e
 		},
 		Result: &FinalizedBlock{},
 	})
-	return b, nil
+	return b
+}
+
+func (b *batchBuilder) RequestLatestBlockHashAndNumber() StarknetBatchBuilder {
+	b.args = append(b.args, gethrpc.BatchElem{
+		Method: "starknet_blockHashAndNumber",
+		Args:   nil,
+		Result: &starknetrpc.BlockHashAndNumberOutput{},
+	})
+	return b
 }
 
 func (b *batchBuilder) Build() []gethrpc.BatchElem {
@@ -54,16 +63,18 @@ type StarknetChainClient interface {
 	// only finalized blocks have a block hashes
 	BlockByHash(ctx context.Context, h *felt.Felt) (FinalizedBlock, error)
 	// only finalized blocks have numbers
-	BlockByNumber(ctx context.Context, id uint64) (FinalizedBlock, error)
+	// BlockByNumber(ctx context.Context, id uint64) (FinalizedBlock, error)
 	// only way to get the latest pending block (only 1 pending block exists at a time)
-	LatestPendingBlock(ctx context.Context) (starknetrpc.PendingBlock, error)
+	// LatestPendingBlock(ctx context.Context) (starknetrpc.PendingBlock, error)
 	// returns block number and block has of latest finalized block
 	LatestBlockHashAndNumber(ctx context.Context) (starknetrpc.BlockHashAndNumberOutput, error)
 	// get block logs, event logs, etc.
-	EventsByFilter(ctx context.Context, f starknetrpc.EventFilter) ([]starknetrpc.EmittedEvent, error)
-	TxReceiptByHash(ctx context.Context, h *felt.Felt) (starknetrpc.TransactionReceipt, error)
-	Batch(builder StarknetBatchBuilder) ([]gethrpc.BatchElem, error)
+	// EventsByFilter(ctx context.Context, f starknetrpc.EventFilter) ([]starknetrpc.EmittedEvent, error)
+	// TxReceiptByHash(ctx context.Context, h *felt.Felt) (starknetrpc.TransactionReceipt, error)
+	Batch(ctx context.Context, builder StarknetBatchBuilder) ([]gethrpc.BatchElem, error)
 }
+
+var _ StarknetChainClient = (*Client)(nil)
 
 func (c *Client) BlockByHash(ctx context.Context, h *felt.Felt) (FinalizedBlock, error) {
 	if c.defaultTimeout != 0 {
@@ -85,6 +96,21 @@ func (c *Client) BlockByHash(ctx context.Context, h *felt.Felt) (FinalizedBlock,
 	}
 
 	return *finalizedBlock, nil
+}
+
+func (c *Client) LatestBlockHashAndNumber(ctx context.Context) (starknetrpc.BlockHashAndNumberOutput, error) {
+	if c.defaultTimeout != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.defaultTimeout)
+		defer cancel()
+	}
+
+	info, err := c.Provider.BlockHashAndNumber(ctx)
+	if err != nil {
+		return starknetrpc.BlockHashAndNumberOutput{}, fmt.Errorf("error in LatestBlockHashAndNumber: %w", err)
+	}
+
+	return *info, nil
 }
 
 func (c *Client) Batch(ctx context.Context, builder StarknetBatchBuilder) ([]gethrpc.BatchElem, error) {

--- a/relayer/pkg/starknet/chain_client_test.go
+++ b/relayer/pkg/starknet/chain_client_test.go
@@ -1,0 +1,111 @@
+package starknet
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/NethermindEth/juno/core/felt"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+)
+
+var (
+	myChainID = "SN_SEPOLIA"
+	myTimeout = 10 * time.Second
+)
+
+func TestChainClient(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		req, _ := io.ReadAll(r.Body)
+		fmt.Println(r.RequestURI, r.URL, string(req))
+
+		var out []byte
+
+		type Call struct {
+			Method string            `json:"method"`
+			Params []json.RawMessage `json:"params"`
+		}
+
+		call := Call{}
+		require.NoError(t, json.Unmarshal(req, &call))
+
+		switch call.Method {
+		case "starknet_getBlockWithTxs":
+			out = []byte(fmt.Sprintf(` 
+			{
+        "result": {
+            "status": "ACCEPTED_ON_L2",
+            "block_hash": "0x725407fcc3bd43e50884f50f1e0ef32aa9f814af3da475411934a7dbd4b41a",
+            "parent_hash": "0x5ac8b4099a26e9331a015f8437feadf56fa7fb447e8183aa1bdb3bf541a2cbb",
+            "block_number": 48719,
+            "new_root": "0x624f0f3cf2fbbd5951b0d90e4e1fc858f3d77cf34303781fcf3e4dc3afaf666",
+            "timestamp": 1710445796,
+            "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+            "l1_gas_price": {
+                "price_in_fri": "0x1d1a94a20000",
+                "price_in_wei": "0x4a817c800"
+            },
+            "starknet_version": "0.13.1",
+            "transactions": [
+                {
+                    "transaction_hash": "0x27a9a9bc927efc37658acfb9c27b1fc56e7cfcf7a30db1ecdd9820bb2dddf0c",
+                    "type": "INVOKE",
+                    "version": "0x1",
+                    "nonce": "0x62b",
+                    "max_fee": "0x271963aac565a",
+                    "sender_address": "0x42db30408353b25c5a0b3dd798bfe98eba08956786374e961cc5dbb9811ec6e",
+                    "signature": [
+                        "0x66f70855f35096c6aea45be365617bc70fca65808bb85332dd3c2f6f4a86071",
+                        "0x43c09cab9be65cdc59b29b8018c201c1eb42d51529cb9b5dd64859652bf827f"
+                    ],
+                    "calldata": [
+                        "0x1",
+                        "0x517567ac7026ce129c950e6e113e437aa3c83716cd61481c6bb8c5057e6923e",
+                        "0xcaffbd1bd76bd7f24a3fa1d69d1b2588a86d1f9d2359b13f6a84b7e1cbd126",
+                        "0xa",
+                        "0x53616d706c654465706f7369745374617274",
+                        "0x8",
+                        "0x4",
+                        "0x18343d00000001",
+                        "0x1",
+                        "0x5",
+                        "0x469",
+                        "0x2",
+                        "0x1",
+                        "0x4eb"
+                    ]
+                }]
+					}
+				}`))
+		case "starknet_blockNumber":
+			out = []byte(`{"result": 1}`)
+		default:
+			require.False(t, true, "unsupported RPC method %s", call.Method)
+		}
+		_, err := w.Write(out)
+		require.NoError(t, err)
+	}))
+	defer mockServer.Close()
+
+	lggr := logger.Test(t)
+	client, err := NewClient(chainID, mockServer.URL, lggr, &myTimeout)
+	require.NoError(t, err)
+	assert.Equal(t, myTimeout, client.defaultTimeout)
+
+	t.Run("get BlockByHash", func(t *testing.T) {
+		blockHash, err := new(felt.Felt).SetString("0x725407fcc3bd43e50884f50f1e0ef32aa9f814af3da475411934a7dbd4b41a")
+		require.NoError(t, err)
+
+		block, err := client.BlockByHash(context.TODO(), blockHash)
+		require.NoError(t, err)
+		assert.Equal(t, blockHash, block.BlockHash)
+	})
+}

--- a/relayer/pkg/starknet/chain_client_test.go
+++ b/relayer/pkg/starknet/chain_client_test.go
@@ -114,7 +114,7 @@ func TestChainClient(t *testing.T) {
 	defer mockServer.Close()
 
 	lggr := logger.Test(t)
-	client, err := NewClient(chainID, mockServer.URL, lggr, &myTimeout)
+	client, err := NewClient(chainID, mockServer.URL, "", lggr, &myTimeout)
 	require.NoError(t, err)
 	assert.Equal(t, myTimeout, client.defaultTimeout)
 

--- a/relayer/pkg/starknet/chain_client_test.go
+++ b/relayer/pkg/starknet/chain_client_test.go
@@ -18,8 +18,53 @@ import (
 )
 
 var (
-	myChainID = "SN_SEPOLIA"
-	myTimeout = 10 * time.Second
+	myChainID     = "SN_SEPOLIA"
+	myTimeout     = 10 * time.Second
+	blockHash, _  = new(felt.Felt).SetString("0x725407fcc3bd43e50884f50f1e0ef32aa9f814af3da475411934a7dbd4b41a")
+	blockResponse = []byte(`
+		"result": {
+				"status": "ACCEPTED_ON_L2",
+				"block_hash": "0x725407fcc3bd43e50884f50f1e0ef32aa9f814af3da475411934a7dbd4b41a",
+				"parent_hash": "0x5ac8b4099a26e9331a015f8437feadf56fa7fb447e8183aa1bdb3bf541a2cbb",
+				"block_number": 48719,
+				"new_root": "0x624f0f3cf2fbbd5951b0d90e4e1fc858f3d77cf34303781fcf3e4dc3afaf666",
+				"timestamp": 1710445796,
+				"sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
+				"l1_gas_price": {
+						"price_in_fri": "0x1d1a94a20000",
+						"price_in_wei": "0x4a817c800"
+				},
+				"starknet_version": "0.13.1",
+				"transactions": [
+						{
+								"transaction_hash": "0x27a9a9bc927efc37658acfb9c27b1fc56e7cfcf7a30db1ecdd9820bb2dddf0c",
+								"type": "INVOKE",
+								"version": "0x1",
+								"nonce": "0x62b",
+								"max_fee": "0x271963aac565a",
+								"sender_address": "0x42db30408353b25c5a0b3dd798bfe98eba08956786374e961cc5dbb9811ec6e",
+								"signature": [
+										"0x66f70855f35096c6aea45be365617bc70fca65808bb85332dd3c2f6f4a86071",
+										"0x43c09cab9be65cdc59b29b8018c201c1eb42d51529cb9b5dd64859652bf827f"
+								],
+								"calldata": [
+										"0x1",
+										"0x517567ac7026ce129c950e6e113e437aa3c83716cd61481c6bb8c5057e6923e",
+										"0xcaffbd1bd76bd7f24a3fa1d69d1b2588a86d1f9d2359b13f6a84b7e1cbd126",
+										"0xa",
+										"0x53616d706c654465706f7369745374617274",
+										"0x8",
+										"0x4",
+										"0x18343d00000001",
+										"0x1",
+										"0x5",
+										"0x469",
+										"0x2",
+										"0x1",
+										"0x4eb"
+								]
+						}]
+			}`)
 )
 
 func TestChainClient(t *testing.T) {
@@ -32,64 +77,37 @@ func TestChainClient(t *testing.T) {
 		type Call struct {
 			Method string            `json:"method"`
 			Params []json.RawMessage `json:"params"`
+			Id     uint              `json:"id,omitempty"`
 		}
 
 		call := Call{}
-		require.NoError(t, json.Unmarshal(req, &call))
+		errMarshal := json.Unmarshal(req, &call)
+		if errMarshal == nil {
+			switch call.Method {
+			case "starknet_getBlockWithTxs":
+				out = []byte(fmt.Sprintf(`{ %s }`, blockResponse))
+			case "starknet_blockNumber":
+				out = []byte(`{"result": 1}`)
+			default:
+				require.False(t, true, "unsupported RPC method %s", call.Method)
+			}
+		} else {
+			// batch method
+			var batchCall []Call
+			errBatchMarshal := json.Unmarshal(req, &batchCall)
+			assert.NoError(t, errBatchMarshal)
 
-		switch call.Method {
-		case "starknet_getBlockWithTxs":
-			out = []byte(fmt.Sprintf(` 
-			{
-        "result": {
-            "status": "ACCEPTED_ON_L2",
-            "block_hash": "0x725407fcc3bd43e50884f50f1e0ef32aa9f814af3da475411934a7dbd4b41a",
-            "parent_hash": "0x5ac8b4099a26e9331a015f8437feadf56fa7fb447e8183aa1bdb3bf541a2cbb",
-            "block_number": 48719,
-            "new_root": "0x624f0f3cf2fbbd5951b0d90e4e1fc858f3d77cf34303781fcf3e4dc3afaf666",
-            "timestamp": 1710445796,
-            "sequencer_address": "0x1176a1bd84444c89232ec27754698e5d2e7e1a7f1539f12027f28b23ec9f3d8",
-            "l1_gas_price": {
-                "price_in_fri": "0x1d1a94a20000",
-                "price_in_wei": "0x4a817c800"
-            },
-            "starknet_version": "0.13.1",
-            "transactions": [
-                {
-                    "transaction_hash": "0x27a9a9bc927efc37658acfb9c27b1fc56e7cfcf7a30db1ecdd9820bb2dddf0c",
-                    "type": "INVOKE",
-                    "version": "0x1",
-                    "nonce": "0x62b",
-                    "max_fee": "0x271963aac565a",
-                    "sender_address": "0x42db30408353b25c5a0b3dd798bfe98eba08956786374e961cc5dbb9811ec6e",
-                    "signature": [
-                        "0x66f70855f35096c6aea45be365617bc70fca65808bb85332dd3c2f6f4a86071",
-                        "0x43c09cab9be65cdc59b29b8018c201c1eb42d51529cb9b5dd64859652bf827f"
-                    ],
-                    "calldata": [
-                        "0x1",
-                        "0x517567ac7026ce129c950e6e113e437aa3c83716cd61481c6bb8c5057e6923e",
-                        "0xcaffbd1bd76bd7f24a3fa1d69d1b2588a86d1f9d2359b13f6a84b7e1cbd126",
-                        "0xa",
-                        "0x53616d706c654465706f7369745374617274",
-                        "0x8",
-                        "0x4",
-                        "0x18343d00000001",
-                        "0x1",
-                        "0x5",
-                        "0x469",
-                        "0x2",
-                        "0x1",
-                        "0x4eb"
-                    ]
-                }]
+			out = []byte(fmt.Sprintf(`
+				[
+					{
+						"jsonrpc": "2.0",
+						"id": %d,
+						%s
 					}
-				}`))
-		case "starknet_blockNumber":
-			out = []byte(`{"result": 1}`)
-		default:
-			require.False(t, true, "unsupported RPC method %s", call.Method)
+				]`, batchCall[0].Id, blockResponse))
+
 		}
+
 		_, err := w.Write(out)
 		require.NoError(t, err)
 	}))
@@ -101,11 +119,23 @@ func TestChainClient(t *testing.T) {
 	assert.Equal(t, myTimeout, client.defaultTimeout)
 
 	t.Run("get BlockByHash", func(t *testing.T) {
-		blockHash, err := new(felt.Felt).SetString("0x725407fcc3bd43e50884f50f1e0ef32aa9f814af3da475411934a7dbd4b41a")
-		require.NoError(t, err)
-
 		block, err := client.BlockByHash(context.TODO(), blockHash)
 		require.NoError(t, err)
+		assert.Equal(t, blockHash, block.BlockHash)
+	})
+
+	t.Run("get Batch", func(t *testing.T) {
+		builder := NewBatchBuilder()
+		builder.RequestBlockByHash(blockHash)
+
+		results, err := client.Batch(context.TODO(), builder)
+		require.NoError(t, err)
+
+		assert.Equal(t, "starknet_getBlockWithTxs", results[0].Method)
+		assert.Nil(t, results[0].Error)
+
+		block, ok := results[0].Result.(*FinalizedBlock)
+		assert.True(t, ok)
 		assert.Equal(t, blockHash, block.BlockHash)
 	})
 }

--- a/relayer/pkg/starknet/chain_client_test.go
+++ b/relayer/pkg/starknet/chain_client_test.go
@@ -19,7 +19,6 @@ import (
 )
 
 var (
-	myChainID     = "SN_SEPOLIA"
 	myTimeout     = 100 * time.Second
 	blockNumber   = 48719
 	blockHash, _  = new(felt.Felt).SetString("0x725407fcc3bd43e50884f50f1e0ef32aa9f814af3da475411934a7dbd4b41a")

--- a/relayer/pkg/starknet/client.go
+++ b/relayer/pkg/starknet/client.go
@@ -43,6 +43,7 @@ var _ ReaderWriter = (*Client)(nil)
 
 type Client struct {
 	Provider       starknetrpc.RpcProvider
+	EthClient      *ethrpc.Client
 	lggr           logger.Logger
 	defaultTimeout time.Duration
 }
@@ -61,9 +62,15 @@ func NewClient(chainID string, baseURL string, apiKey string, lggr logger.Logger
 		return nil, err
 	}
 
+	c, err := ethrpc.DialContext(context.Background(), baseURL)
+	if err != nil {
+		return nil, err
+	}
+
 	client := &Client{
-		Provider: provider,
-		lggr:     lggr,
+		Provider:  provider,
+		EthClient: c,
+		lggr:      lggr,
 	}
 
 	// make copy to preserve value


### PR DESCRIPTION
https://smartcontract-it.atlassian.net/browse/BCI-2676


Adding 3 block-related methods so RTSP can begin playing around with fetching blocks and the Batch() method to lay the groundwork for the rest of the methods. Rest of the process should be straightforward after this PR.

Added the ChainId method as well. Turns out the starknet.go provider automatically caches the chainId after first request, so our implementation uses the batchCall always

Original Design Doc: https://docs.google.com/document/d/10jsfp7_VqDv2GFGILmTX2ey-p_yaFyvxPaVszL6kg6g/edit

Open Questions:
* ~For batch calls, the user will need to iterate through the batchElem array and[ cast the Result interface ](https://github.com/smartcontractkit/chainlink-starknet/pull/373/files#diff-eea92d0b7802160d247d8ea230688c30cb2849810928b097331222df6ac5e7a3R171) to the expected return type. This seems like a weird user experience so I'm open to feedback on how to improve this.~ RESOLVED
