### PR TITLE
[BCI-2714]: adds sncast scripts V2

### DIFF
--- a/examples/contracts/aggregator_consumer/Makefile
+++ b/examples/contracts/aggregator_consumer/Makefile
@@ -36,7 +36,7 @@ add-account:
 		&& cat $(DEVNET_ACCOUNTS_FILE) \
 
 deploy-account:
-	@sncast --profile testnet account deploy --name "$(TESTNET_ACCOUNT_NAME)"
+	@sncast --profile testnet account deploy --name "$(TESTNET_ACCOUNT_NAME)" --max-fee 0x5af3107a3fff
 
 # MockAggregator Commands
 

--- a/examples/contracts/aggregator_consumer/README.md
+++ b/examples/contracts/aggregator_consumer/README.md
@@ -172,84 +172,50 @@ Once the container is restarted, let's deploy the MockAggregator contract and th
 make devnet-deploy
 ```
 
-The AggregatorConsumer takes the address of an aggregator contract as input (in this case it is the MockAggregator). It comes with two methods:
+The AggregatorConsumer is a simple contract that can be used to store the latest answer of an Aggregator contract. It takes the address of an aggregator contract as input (in this case it is the MockAggregator), and it comes with the following methods:
 
-- `set_answer`: this function reads the latest round data from the aggregator and stores the round answer in storage.
+- `set_answer`: this function sets the answer to a new value.
 - `read_answer`: this function reads the answer from storage. The answer is initially set to 0 on deployment.
+- `read_ocr_address`: this function returns the address of the aggregator contract.
 
-At this point, the latest round data has not been set, so calling `set_answer` on the AggregatorConsumer contract will trivially set the answer to 0. You can run the following commands to verify this:
+At this point, the AggregatorConsumer's answer has not been set, so calling `read_answer` on the AggregatorConsumer contract will return 0. You can run the following commands to verify this:
 
-- Let's check that the answer is initially set to 0:
-
-  Command:
-
-  ```sh
-  make ac-read-answer NETWORK=devnet
-  ```
-
-  Output:
-
-
-  ```text
-  Result::Ok(CallResult { data: [0] })
-  command: script run
-  status: success
-  ```
-
-- Let's set the answer:
-
-  Command:
-
-  ```sh
-  make ac-set-answer NETWORK=devnet 
-  ```
-
-  Output:
-
-  ```text
-  Transaction hash = 0x7897b80451a4e4d6df1dc575fffe9b6ebc774bd675eb24c8cf83e0a3818071
-  Result::Ok(InvokeResult { transaction_hash: 213068772556793858646692905972104002796353690311811440814152767066255491185 })
-  command: script run
-  status: success
-  ```
-
-- The answer should still be 0:
-
-  Command:
-
-  ```sh
-  make ac-read-answer NETWORK=devnet
-  ```
-
-  Output:
-
-
-  ```text
-  Result::Ok(CallResult { data: [0] })
-  command: script run
-  status: success
-  ```
-
-
-To change this, let's set the latest round data to some dummy values:
-
-```sh
-make ma-set-latest-round NETWORK=devnet 
-```
-
-Then let's refresh the AggregatorConsumer's answer:
-
-```sh
-make ac-set-answer NETWORK=devnet 
-```
-
-Finally, let's read the AggregatorConsumer's answer:
+Command:
 
 ```sh
 make ac-read-answer NETWORK=devnet
 ```
 
-This should result in the following:
+Output:
+
+
+```text
+Result::Ok(CallResult { data: [0] })
+command: script run
+status: success
+```
+
+To change this, let's use the set the MockAggregator's latest round data to some dummy values:
+
+```sh
+make ma-set-latest-round NETWORK=devnet 
+```
+
+Now let's query the latest round data from the MockAggregator and store the latest round answer in the AggregatorConsumer:
+
+```sh
+make ac-set-answer NETWORK=devnet 
+```
+
+Now, reading the AggregatorConsumer's answer returns a non-zero value:
+
+Command:
+
+```sh
+make ac-read-answer NETWORK=devnet
+```
+
+Output:
 
 ```text
 Result::Ok(CallResult { data: [1] })

--- a/examples/contracts/aggregator_consumer/scripts/src/aggregator/read_decimals.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/aggregator/read_decimals.cairo
@@ -9,7 +9,7 @@ fn main() {
         .try_into()
         .unwrap();
 
-    let result = call(aggregator_address, selector!("read_decimals"), array![]);
+    let result = call(aggregator_address, selector!("decimals"), array![]);
     if result.is_err() {
         println!("{:?}", result.unwrap_err());
         panic_with_felt252('call failed');

--- a/examples/contracts/aggregator_consumer/scripts/src/aggregator/read_decimals.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/aggregator/read_decimals.cairo
@@ -5,7 +5,7 @@ use starknet::ContractAddress;
 fn main() {
     // If you are using testnet, this address may need to be changed
     // If you are using the local starknet-devnet-rs container, this can be left alone
-    let aggregator_address = 0x376b1abf788737bded2011a0f76ce61cabdeaec22e97b8a4e231b149dd49fc0
+    let aggregator_address = 0x3c6f82da5dbfa89ec9dbe414f33d23d1720d15568e4a880afcc9b0c3d98d127
         .try_into()
         .unwrap();
 

--- a/examples/contracts/aggregator_consumer/scripts/src/aggregator/read_latest_round.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/aggregator/read_latest_round.cairo
@@ -5,7 +5,7 @@ use starknet::ContractAddress;
 fn main() {
     // If you are using testnet, this address may need to be changed
     // If you are using the local starknet-devnet-rs container, this can be left alone
-    let aggregator_address = 0x376b1abf788737bded2011a0f76ce61cabdeaec22e97b8a4e231b149dd49fc0
+    let aggregator_address = 0x3c6f82da5dbfa89ec9dbe414f33d23d1720d15568e4a880afcc9b0c3d98d127
         .try_into()
         .unwrap();
 

--- a/examples/contracts/aggregator_consumer/scripts/src/consumer/deploy_aggregator_consumer.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/consumer/deploy_aggregator_consumer.cairo
@@ -9,7 +9,7 @@ fn declare_and_deploy(
     contract_name: ByteArray, constructor_calldata: Array<felt252>
 ) -> DeployResult {
     let mut class_hash: ClassHash =
-        0x100157fc2d1c88776e1c9b75dd6ee62e83212f45f6c4b511e02e1d5d3ae08f6
+        0x6d1dd0e5fa4e0284dcf341997f1d781bc2fb7d76ada684da7a2a33c38031df5
         .try_into()
         .unwrap();
 

--- a/examples/contracts/aggregator_consumer/scripts/src/consumer/deploy_aggregator_consumer.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/consumer/deploy_aggregator_consumer.cairo
@@ -9,7 +9,7 @@ fn declare_and_deploy(
     contract_name: ByteArray, constructor_calldata: Array<felt252>
 ) -> DeployResult {
     let mut class_hash: ClassHash =
-        0x4ef1d23b415f7edbb2d9f31fb86d91e84394316f44645467005a2d579380dbd
+        0x100157fc2d1c88776e1c9b75dd6ee62e83212f45f6c4b511e02e1d5d3ae08f6
         .try_into()
         .unwrap();
 
@@ -44,7 +44,7 @@ fn declare_and_deploy(
 fn main() {
     // Point this to the address of the aggregator contract you'd like to use
     let aggregator_address: ContractAddress =
-        0x376b1abf788737bded2011a0f76ce61cabdeaec22e97b8a4e231b149dd49fc0
+        0x3c6f82da5dbfa89ec9dbe414f33d23d1720d15568e4a880afcc9b0c3d98d127
         .try_into()
         .unwrap();
 

--- a/examples/contracts/aggregator_consumer/scripts/src/consumer/read_answer.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/consumer/read_answer.cairo
@@ -5,7 +5,7 @@ use starknet::ContractAddress;
 fn main() {
     // If you are using testnet, this address may need to be changed
     // If you are using the local starknet-devnet-rs container, this can be left alone
-    let consumer_address = 0x622f81d884ed45b3874e038b38f7e1c6dcbe789dc96da5161c17d47d9c53570
+    let consumer_address = 0x5b12015734ce4bc3c72f9ae4d87ed80e2a28497b21e220a702d1e20e854b0cd
         .try_into()
         .unwrap();
 

--- a/examples/contracts/aggregator_consumer/scripts/src/consumer/read_answer.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/consumer/read_answer.cairo
@@ -5,7 +5,7 @@ use starknet::ContractAddress;
 fn main() {
     // If you are using testnet, this address may need to be changed
     // If you are using the local starknet-devnet-rs container, this can be left alone
-    let consumer_address = 0x5b12015734ce4bc3c72f9ae4d87ed80e2a28497b21e220a702d1e20e854b0cd
+    let consumer_address = 0x56e078ee90929f13f2ca83545c71b98136c99b22822ada66ad2aff9595439fc
         .try_into()
         .unwrap();
 

--- a/examples/contracts/aggregator_consumer/scripts/src/consumer/set_answer.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/consumer/set_answer.cairo
@@ -5,7 +5,7 @@ use starknet::ContractAddress;
 fn main() {
     // If you are using testnet, this address may need to be changed
     // If you are using the local starknet-devnet-rs container, this can be left alone
-    let consumer_address = 0x622f81d884ed45b3874e038b38f7e1c6dcbe789dc96da5161c17d47d9c53570
+    let consumer_address = 0x5b12015734ce4bc3c72f9ae4d87ed80e2a28497b21e220a702d1e20e854b0cd
         .try_into()
         .unwrap();
 

--- a/examples/contracts/aggregator_consumer/scripts/src/consumer/set_answer.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/consumer/set_answer.cairo
@@ -1,22 +1,48 @@
-use sncast_std::{invoke, InvokeResult, get_nonce};
+use sncast_std::{invoke, InvokeResult, call, CallResult, get_nonce};
 
 use starknet::ContractAddress;
 
 fn main() {
     // If you are using testnet, this address may need to be changed
     // If you are using the local starknet-devnet-rs container, this can be left alone
-    let consumer_address = 0x5b12015734ce4bc3c72f9ae4d87ed80e2a28497b21e220a702d1e20e854b0cd
+    let consumer_address = 0x56e078ee90929f13f2ca83545c71b98136c99b22822ada66ad2aff9595439fc
         .try_into()
         .unwrap();
 
+    // Reads the aggregator address from the AggregatorConsumer
+    let read_ocr_address = call(consumer_address, selector!("read_ocr_address"), array![]);
+    if read_ocr_address.is_err() {
+        println!("{:?}", read_ocr_address.unwrap_err());
+        panic_with_felt252('call failed');
+    } else {
+        println!("{:?}", read_ocr_address);
+    }
+
+    // Queries the aggregator for the latest round data
+    let mut read_ocr_address_data = read_ocr_address.unwrap().data.span();
+    let aggregator_address = Serde::<
+        starknet::ContractAddress
+    >::deserialize(ref read_ocr_address_data)
+        .unwrap();
+    let latest_round = call(aggregator_address, selector!("latest_round_data"), array![]);
+    if latest_round.is_err() {
+        println!("{:?}", latest_round.unwrap_err());
+        panic_with_felt252('call failed');
+    } else {
+        println!("{:?}", latest_round);
+    }
+
+    // Uses the latest round data to set a new answer on the AggregatorConsumer
+    let mut latest_round_data = latest_round.unwrap().data.span();
+    let round = Serde::<chainlink::ocr2::aggregator::Round>::deserialize(ref latest_round_data)
+        .unwrap();
     let result = invoke(
         consumer_address,
         selector!("set_answer"),
-        array![],
+        array![round.answer.into()],
         Option::None,
         Option::Some(get_nonce('pending'))
     );
-
     if result.is_err() {
         println!("{:?}", result.unwrap_err());
         panic_with_felt252('invoke failed');

--- a/examples/contracts/aggregator_consumer/scripts/src/example.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/example.cairo
@@ -1,11 +1,15 @@
 use sncast_std::{call, CallResult};
 
 fn main() {
-    let eth = 0x049d36570d4e46f48e99674bd3fcc84644ddd6b96f7c741b1562b82f9e004dc7;
-    let call_result = call(eth.try_into().unwrap(), selector!("decimals"), array![])
-        .expect('call failed');
-    let call_result = *call_result.data[0];
-    assert(call_result == 18, call_result);
-    println!("{:?}", call_result);
+    let address = 0x775ee7f2f0b3e15953f4688f7a2ce5a0d1e7c8e18e5f929d461c037f14b690e
+        .try_into()
+        .unwrap();
+    let result = call(address, selector!("description"), array![]);
+    if result.is_err() {
+        println!("{:?}", result.unwrap_err());
+        panic_with_felt252('call failed');
+    } else {
+        println!("{:?}", result);
+    }
 }
 

--- a/examples/contracts/aggregator_consumer/scripts/src/mock_aggregator/deploy_mock_aggregator.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/mock_aggregator/deploy_mock_aggregator.cairo
@@ -8,7 +8,8 @@ use starknet::{ContractAddress, ClassHash};
 fn declare_and_deploy(
     contract_name: ByteArray, constructor_calldata: Array<felt252>
 ) -> DeployResult {
-    let mut class_hash: ClassHash = 0xaaadc5e958f8fdc8e81a03cc7429e2129474419e4ac3210e316f73addf1e31
+    let mut class_hash: ClassHash =
+        0x728d8a221e2204c88df0642b7c6dcee60f7c3d3b3d5c190cac1ceba5baf15e8
         .try_into()
         .unwrap();
 

--- a/examples/contracts/aggregator_consumer/scripts/src/mock_aggregator/set_latest_round.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/mock_aggregator/set_latest_round.cairo
@@ -5,7 +5,7 @@ use starknet::ContractAddress;
 fn main() {
     // If you are using testnet, this address may need to be changed
     // If you are using the local starknet-devnet-rs container, this can be left alone
-    let mock_aggregator_address = 0x376b1abf788737bded2011a0f76ce61cabdeaec22e97b8a4e231b149dd49fc0
+    let mock_aggregator_address = 0x3c6f82da5dbfa89ec9dbe414f33d23d1720d15568e4a880afcc9b0c3d98d127
         .try_into()
         .unwrap();
 

--- a/examples/contracts/aggregator_consumer/scripts/src/mock_aggregator/set_latest_round.cairo
+++ b/examples/contracts/aggregator_consumer/scripts/src/mock_aggregator/set_latest_round.cairo
@@ -12,8 +12,8 @@ fn main() {
     // Feel free to modify these 
     let answer = 1;
     let block_num = 12345;
-    let observation_timestamp = 100000;
-    let transmission_timestamp = 200000;
+    let observation_timestamp = 1711716556;
+    let transmission_timestamp = 1711716514;
 
     let result = invoke(
         mock_aggregator_address,

--- a/examples/contracts/aggregator_consumer/src/ocr2/consumer.cairo
+++ b/examples/contracts/aggregator_consumer/src/ocr2/consumer.cairo
@@ -1,7 +1,9 @@
 #[starknet::interface]
 pub trait IAggregatorConsumer<TContractState> {
+    fn read_latest_round(self: @TContractState) -> chainlink::ocr2::aggregator::Round;
+    fn read_ocr_address(self: @TContractState) -> starknet::ContractAddress;
     fn read_answer(self: @TContractState) -> u128;
-    fn set_answer(ref self: TContractState);
+    fn set_answer(ref self: TContractState, answer: u128);
 }
 
 #[starknet::contract]
@@ -29,14 +31,22 @@ mod AggregatorConsumer {
 
     #[abi(embed_v0)]
     impl AggregatorConsumerImpl of super::IAggregatorConsumer<ContractState> {
-        fn set_answer(ref self: ContractState) {
-            let round = IAggregatorDispatcher { contract_address: self._ocr_address.read() }
+        fn read_latest_round(self: @ContractState) -> Round {
+            return IAggregatorDispatcher { contract_address: self._ocr_address.read() }
                 .latest_round_data();
-            self._answer.write(round.answer);
+        }
+
+
+        fn set_answer(ref self: ContractState, answer: u128) {
+            self._answer.write(answer);
         }
 
         fn read_answer(self: @ContractState) -> u128 {
             return self._answer.read();
+        }
+
+        fn read_ocr_address(self: @ContractState) -> ContractAddress {
+            return self._ocr_address.read();
         }
     }
 }


### PR DESCRIPTION
Adds various fixes to: https://github.com/smartcontractkit/chainlink-starknet/pull/396:

- Adds a `--max-fee` flag to the testnet account deployment command
- In `read_decimals.cairo`, the "read_decimals" selector has been replaced with "decimals"
- Resolves an issue with the `make ac-set-answer` command on testnet where calling it with a non-mock aggregator contract throws a read access permission error
- Updates the hardcoded class hashes and addresses in the example scripts (the updates to snfoundry, scarb, and cairo have caused these to change)