### PR TITLE
use latest data not pending

### DIFF
--- a/relayer/pkg/chainlink/ocr2/client.go
+++ b/relayer/pkg/chainlink/ocr2/client.go
@@ -215,7 +215,7 @@ func (c *Client) fetchEventsFromBlock(ctx context.Context, address *felt.Felt, e
 	}
 
 	if len(events) == 0 {
-		return nil, errors.New("events not found in the block")
+		return nil, fmt.Errorf("events not found in the block %d", blockNum)
 	}
 	return events, nil
 }

--- a/relayer/pkg/starknet/client.go
+++ b/relayer/pkg/starknet/client.go
@@ -86,7 +86,7 @@ func (c *Client) CallContract(ctx context.Context, ops CallOps) (data []*felt.Fe
 		Calldata:           ops.Calldata,
 	}
 
-	res, err := c.Call(ctx, tx, starknetrpc.WithBlockTag("pending"))
+	res, err := c.Call(ctx, tx, starknetrpc.WithBlockTag("latest"))
 	if err != nil {
 		return nil, errors.Wrap(err, "error in client.CallContract")
 	}


### PR DESCRIPTION
Contract calls should be made with the latest finalized block data not the pending data.

Fixing this should resolve issues on the monitoring server where we are getting pending data and treating it like finalized data that can be queried
