### PR TITLE
BCI-3127: write lastConfigDigest to rdd

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -9,7 +9,7 @@ mockery 2.22.1
 golangci-lint 1.55.0
 actionlint 1.6.12
 shellcheck 0.8.0
-scarb 2.5.4
+scarb 2.6.3
 postgres 15.1
 
 # Kubernetes

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
@@ -16,7 +16,6 @@ import { decodeOffchainConfigFromEventData } from '../../lib/encoding'
 import assert from 'assert'
 import { getLatestOCRConfigEvent } from './inspection/configEvent'
 import { BigNumberish, GetTransactionReceiptResponse } from 'starknet'
-import { saveJSON } from '@chainlink/gauntlet-core/dist/utils/io'
 
 type Oracle = {
   signer: string

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
@@ -185,15 +185,15 @@ const afterExecute: AfterExecute<SetConfigInput, ContractInput> = (context, inpu
 
     // write lastConfigDigest back to RDD
     const configDigest = `0x${(event.latest_config_digest as bigint).toString(16)}`
-    deps.logger.info(`lastConfigDigest to save in RDD: ${configDigest}`)
+    deps.logger.info(`ℹ️  lastConfigDigest to save in RDD: ${configDigest}`)
     if (context.flags.rdd) {
-      deps.logger.info(`rdd file found! will automatically lastConfigDigest for you`)
+      deps.logger.info(`ℹ️ RDD file ${context.flags.rdd} found! Will automatically update lastConfigDigest for you`)
       const rdd = getRDD(context.flags.rdd)
       const newRdd = { ...rdd, ...{ 'lastConfigDigest': configDigest } }
       fs.writeFileSync(context.flags.rdd, JSON.stringify(newRdd, null, 2))
-      deps.logger.info(`rdd file ${context.flags.rdd} updated. please reformat file`)
+      deps.logger.info(`✅ RDD file ${context.flags.rdd} updated. Please reformat (run ./bin/generate and ./bin/degenerate) as needed`)
     } else {
-      deps.logger.info(`You must manually update lastConfigDigest yourself`)
+      deps.logger.info(`❗❗ no rdd file input, you must manually update lastConfigDigest in rdd yourself`)
     }
 
     return { successfulConfiguration: true }

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
@@ -185,13 +185,14 @@ const afterExecute: AfterExecute<SetConfigInput, ContractInput> = (context, inpu
 
     // write lastConfigDigest back to RDD
     const configDigest = `0x${(event.latest_config_digest as bigint).toString(16)}`
-    deps.logger.info(`ℹ️  lastConfigDigest to save in RDD: ${configDigest}`)
+    deps.logger.info(`ℹ️ lastConfigDigest to save in RDD: ${configDigest}`)
     if (context.flags.rdd) {
       deps.logger.info(`ℹ️ RDD file ${context.flags.rdd} found! Will automatically update lastConfigDigest for you`)
       const rdd = getRDD(context.flags.rdd)
-      const newRdd = { ...rdd, ...{ 'lastConfigDigest': configDigest } }
+      const newConfig = { ...rdd.config, ...{ 'lastConfigDigest': configDigest } }
+      const newRdd = { ...rdd, ...{ config: newConfig } }
       fs.writeFileSync(context.flags.rdd, JSON.stringify(newRdd, null, 2))
-      deps.logger.info(`✅ RDD file ${context.flags.rdd} updated. Please reformat (run ./bin/generate and ./bin/degenerate) as needed`)
+      deps.logger.info(`✅ RDD file ${context.flags.rdd} updated. Please reformat RDD (run ./bin/generate and ./bin/degenerate) as needed`)
     } else {
       deps.logger.info(`❗❗ no rdd file input, you must manually update lastConfigDigest in rdd yourself`)
     }

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
@@ -187,14 +187,20 @@ const afterExecute: AfterExecute<SetConfigInput, ContractInput> = (context, inpu
     const configDigest = `0x${(event.latest_config_digest as bigint).toString(16)}`
     deps.logger.info(`ℹ️ lastConfigDigest to save in RDD: ${configDigest}`)
     if (context.flags.rdd) {
-      deps.logger.info(`ℹ️ RDD file ${context.flags.rdd} found! Will automatically update lastConfigDigest for you`)
+      deps.logger.info(
+        `ℹ️ RDD file ${context.flags.rdd} found! Will automatically update lastConfigDigest for you`,
+      )
       const rdd = getRDD(context.flags.rdd)
-      const newConfig = { ...rdd.config, ...{ 'lastConfigDigest': configDigest } }
+      const newConfig = { ...rdd.config, ...{ lastConfigDigest: configDigest } }
       const newRdd = { ...rdd, ...{ config: newConfig } }
       fs.writeFileSync(context.flags.rdd, JSON.stringify(newRdd, null, 2))
-      deps.logger.info(`✅ RDD file ${context.flags.rdd} updated. Please reformat RDD (run ./bin/generate and ./bin/degenerate) as needed`)
+      deps.logger.info(
+        `✅ RDD file ${context.flags.rdd} updated. Please reformat RDD (run ./bin/generate and ./bin/degenerate) as needed`,
+      )
     } else {
-      deps.logger.info(`❗❗ no rdd file input, you must manually update lastConfigDigest in rdd yourself`)
+      deps.logger.info(
+        `❗❗ no rdd file input, you must manually update lastConfigDigest in rdd yourself`,
+      )
     }
 
     return { successfulConfiguration: true }

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
@@ -173,7 +173,6 @@ const afterExecute: AfterExecute<SetConfigInput, ContractInput> = (context, inpu
   if (!txInfo.isSuccess()) {
     return { successfulConfiguration: false }
   }
-  const eventData = txInfo.events[0].data
   const events = context.contract.parseEvents(txInfo)
   const event = events[events.length - 1]['ConfigSet']
   const offchainConfig = decodeOffchainConfigFromEventData(event.offchain_config as BigNumberish[])

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
@@ -184,12 +184,12 @@ const afterExecute: AfterExecute<SetConfigInput, ContractInput> = (context, inpu
     deps.logger.success('Configuration was successfully set')
 
     // write lastConfigDigest back to RDD
-    const configDigest = event.latest_config_digest as BigNumberish
-    deps.logger.info(`lastConfigDigest to save in RDD: ${configDigest.toString()}`)
+    const configDigest = `0x${(event.latest_config_digest as bigint).toString(16)}`
+    deps.logger.info(`lastConfigDigest to save in RDD: ${configDigest}`)
     if (context.flags.rdd) {
       deps.logger.info(`rdd file found! will automatically lastConfigDigest for you`)
       const rdd = getRDD(context.flags.rdd)
-      const newRdd = { ...rdd, ...{ 'lastConfigDigest': configDigest.toString() } }
+      const newRdd = { ...rdd, ...{ 'lastConfigDigest': configDigest } }
       fs.writeFileSync(context.flags.rdd, JSON.stringify(newRdd, null, 2))
       deps.logger.info(`rdd file ${context.flags.rdd} updated. please reformat file`)
     } else {

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
@@ -184,7 +184,7 @@ const afterExecute: AfterExecute<SetConfigInput, ContractInput> = (context, inpu
     deps.logger.success('Configuration was successfully set')
 
     // write lastConfigDigest back to RDD
-    const configDigest = `0x${(event.latest_config_digest as bigint).toString(16)}`
+    const configDigest = `0x0${(event.latest_config_digest as bigint).toString(16)}`
     deps.logger.info(`ℹ️ lastConfigDigest to save in RDD: ${configDigest}`)
     if (context.flags.rdd) {
       deps.logger.info(


### PR DESCRIPTION
RDD field config.lastConfigDigest is required by OCR telemetry Exporter (OTEP)

This change adds ability to read lastConfigDigest from the transaction receipt and populate the `config: { lastConfigDigest: <> } }` field in the rdd file. This keeps the field up to date whenever there is a call to setConfig

