### PR TITLE
Batching MVP

### DIFF
--- a/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
@@ -141,7 +141,7 @@ describe('OCR2 Contract', () => {
   )
 
   it(
-    'Set billing using --batch',
+    'Set billing',
     async () => {
       // transfer overflow on set billing
       const command = await registerExecuteCommand(setBillingCommand).create(
@@ -152,7 +152,6 @@ describe('OCR2 Contract', () => {
             gasBase: 14951,
             gasPerSignature: 13,
           },
-          batch: true,
         },
         feedAddresses,
       )
@@ -196,12 +195,11 @@ describe('OCR2 Contract', () => {
   )
 
   it(
-    'Set config using --input and --batch',
+    'Set config using --input',
     async () => {
       const command = await registerExecuteCommand(setConfigCommand).create(
         {
           input: validInput,
-          batch: true,
         },
         feedAddresses,
       )
@@ -261,13 +259,12 @@ describe('OCR2 Contract', () => {
   )
 
   it(
-    'Transfer ownership using --batch',
+    'Transfer ownership',
     async () => {
       const command = await registerExecuteCommand(transferOwnershipCommand).create(
         {
           // Trivially transfer ownership to the same address
           newOwner: owner.address,
-          batch: true,
         },
         feedAddresses,
       )
@@ -301,14 +298,9 @@ describe('OCR2 Contract', () => {
   )
 
   it(
-    'Accept ownership using --batch',
+    'Accept ownership',
     async () => {
-      const command = await registerExecuteCommand(acceptOwnershipCommand).create(
-        {
-          batch: true,
-        },
-        feedAddresses,
-      )
+      const command = await registerExecuteCommand(acceptOwnershipCommand).create({}, feedAddresses)
 
       // Execute the command
       const report = await command.execute()

--- a/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
@@ -2,6 +2,8 @@ import { makeProvider } from '@chainlink/starknet-gauntlet'
 import deployCommand from '../../src/commands/ocr2/deploy'
 import setBillingCommand from '../../src/commands/ocr2/setBilling'
 import setConfigCommand from '../../src/commands/ocr2/setConfig'
+import transferOwnershipCommand from '../../src/commands/ocr2/transferOwnership'
+import acceptOwnershipCommand from '../../src/commands/ocr2/acceptOwnership'
 import deployACCommand from '../../src/commands/accessController/deploy'
 import {
   registerExecuteCommand,
@@ -71,13 +73,28 @@ const validInput = {
   secret: 'awe accuse polygon tonic depart acuity onyx inform bound gilbert expire',
 }
 
+const getNumCallsPerAddress = (txReceipt: InvokeTransactionReceiptResponse) => {
+  const counter = new Map<string, number>()
+  txReceipt.events.forEach((ev) => {
+    const count = counter.get(ev.from_address)
+    if (count == null) {
+      counter.set(ev.from_address, 1)
+    } else {
+      counter.set(ev.from_address, count + 1)
+    }
+  })
+  return counter
+}
+
 describe('OCR2 Contract', () => {
-  let account: StarknetAccount
-  let contractAddress: string
+  const feedAddresses = new Array<string>()
+  const numFeeds = 3
+
+  let owner: StarknetAccount
   let accessController: string
 
   beforeAll(async () => {
-    account = await fetchAccount()
+    owner = await fetchAccount()
   })
 
   it(
@@ -96,25 +113,29 @@ describe('OCR2 Contract', () => {
   it(
     'Deployment',
     async () => {
-      const command = await registerExecuteCommand(deployCommand).create(
-        {
-          input: {
-            owner: account.address,
-            maxAnswer: 10000,
-            minAnswer: 1,
-            decimals: 18,
-            description: 'Test Feed',
-            billingAccessController: accessController,
-            linkToken: '0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603730',
+      // Deploys one feed at a time (if we try to do this in parallel using
+      // `Promise.all` / `Promise.allSettled`, then transaction nonce errors
+      // will occur)
+      for (let i = 0; i < numFeeds; i++) {
+        const command = await registerExecuteCommand(deployCommand).create(
+          {
+            input: {
+              owner: owner.address,
+              maxAnswer: 10000,
+              minAnswer: 1,
+              decimals: 18,
+              description: `Test Feed ${i}`,
+              billingAccessController: accessController,
+              linkToken: '0x04cc1bfa99e282e434aef2815ca17337a923cd2c61cf0c7de5b326d7a8603730',
+            },
           },
-        },
-        [],
-      )
+          [],
+        )
 
-      const report = await command.execute()
-      expect(report.responses[0].tx.status).toEqual('ACCEPTED')
-
-      contractAddress = report.responses[0].contract
+        const report = await command.execute()
+        expect(report.responses[0].tx.status).toEqual('ACCEPTED')
+        feedAddresses.push(report.responses[0].contract)
+      }
     },
     TIMEOUT,
   )
@@ -122,9 +143,6 @@ describe('OCR2 Contract', () => {
   it(
     'Set billing using --batch',
     async () => {
-      // the number of calls to batch into one transaction
-      const batchCount = 3
-
       // transfer overflow on set billing
       const command = await registerExecuteCommand(setBillingCommand).create(
         {
@@ -136,36 +154,42 @@ describe('OCR2 Contract', () => {
           },
           batch: true,
         },
-        // Calls set_billing on the same contract `batchCount` times (with the
-        // same input) using one transaction. We use the same contract address
-        // here for simplicity, but a more realistic example would involve using
-        // different contract addresses (where each of them has the same ABI)
-        // and passing different inputs to each of them.
-        Array.from({ length: batchCount }).map(() => contractAddress),
+        feedAddresses,
       )
 
+      // Execute the command
       const report = await command.execute()
       const maybeRes = report.responses.at(0)
       expect(maybeRes).not.toBeFalsy()
 
+      // Validate the response
       const res = maybeRes!
       expect(res.tx.status).toEqual('ACCEPTED')
       expect(res.tx.hash).not.toBeNull()
 
-      // Checks that the update was successful
+      // Checks that the transaction was successful
       const provider: RpcProvider = makeProvider(LOCAL_URL).provider
-      const { contract } = loadContract(CONTRACT_LIST.OCR2)
-      const ocr2Contract = new Contract(contract.abi, contractAddress, provider)
-      const billing = await ocr2Contract.billing()
-      expect(billing.observation_payment_gjuels).toEqual(BigInt(1))
-      expect(billing.transmission_payment_gjuels).toEqual(BigInt(1))
-
-      // Checks that the correct number of batch calls were made
       const receipt = await provider.waitForTransaction(res.tx.hash)
       expect(receipt.isSuccess()).toBeTruthy()
-      if (receipt.isSuccess()) {
-        const invocations = receipt.events.filter((ev) => ev.from_address === contractAddress)
-        expect(invocations.length).toEqual(batchCount)
+      const txReceipt = receipt as InvokeTransactionReceiptResponse
+
+      // Loads the contract
+      const { contract } = loadContract(CONTRACT_LIST.OCR2)
+
+      // Creates a map where each key is an address and each corresponding value is
+      // the number of times the address is seen in the transaction receipt events
+      const counter = getNumCallsPerAddress(txReceipt)
+
+      // Iterate over the feeds
+      for (const feedAddress of feedAddresses) {
+        // Checks that the feed was updated
+        const ocr2Contract = new Contract(contract.abi, feedAddress, provider)
+        const billing = await ocr2Contract.billing()
+        expect(billing.observation_payment_gjuels).toEqual(BigInt(1))
+        expect(billing.transmission_payment_gjuels).toEqual(BigInt(1))
+
+        // Checks that the correct number of batch calls were made
+        expect(counter.get(feedAddress) ?? 0).toEqual(1)
       }
     },
     TIMEOUT,
@@ -174,59 +198,142 @@ describe('OCR2 Contract', () => {
   it(
     'Set config using --input and --batch',
     async () => {
-      // the number of calls to batch into one transaction
-      const batchCount = 3
-
       const command = await registerExecuteCommand(setConfigCommand).create(
         {
           input: validInput,
           batch: true,
         },
-        // Calls set_config on the same contract `batchCount` times (with the
-        // same input) using one transaction. We use the same contract address
-        // here for simplicity, but a more realistic example would involve using
-        // different contract addresses (where each of them has the same ABI)
-        // and passing different inputs to each of them.
-        Array.from({ length: batchCount }).map(() => contractAddress),
+        feedAddresses,
       )
 
+      // Execute the command
       const report = await command.execute()
       const maybeRes = report.responses.at(0)
       expect(maybeRes).not.toBeFalsy()
 
+      // Validate the response
       const res = maybeRes!
       expect(res.tx.status).toEqual('ACCEPTED')
       expect(res.tx.hash).not.toBeNull()
 
+      // Checks that the transaction was successful
       const provider: RpcProvider = makeProvider(LOCAL_URL).provider
-      const { contract } = loadContract(CONTRACT_LIST.OCR2)
-      const ocr2Contract = new Contract(contract.abi, contractAddress, provider)
-      const resultTransmitters = await ocr2Contract.transmitters()
+      const receipt = await provider.waitForTransaction(res.tx.hash)
+      expect(receipt.isSuccess()).toBeTruthy()
+      const txReceipt = receipt as InvokeTransactionReceiptResponse
 
-      // retrieve signer keys from transaction event
-      // based on event struct: https://github.com/smartcontractkit/chainlink-starknet/blob/develop/contracts/src/chainlink/ocr2/aggregator.cairo#L260
-      const receipt = (await provider.getTransactionReceipt(
-        res.tx.hash,
-      )) as InvokeTransactionReceiptResponse
+      // Loads the contract
+      const { contract } = loadContract(CONTRACT_LIST.OCR2)
+
+      // Creates a map where each key is an address and each corresponding value is
+      // the number of times the address is seen in the transaction receipt events
+      const counter = getNumCallsPerAddress(txReceipt)
+
+      // Iterate over the feeds
+      for (const feedAddress of feedAddresses) {
+        // Get a reference to the contract
+        const ocr2Contract = new Contract(contract.abi, feedAddress, provider)
+        const resultTransmitters = await ocr2Contract.transmitters()
+
+        // retrieve signer keys from transaction event
+        // based on event struct: https://github.com/smartcontractkit/chainlink-starknet/blob/develop/contracts/src/chainlink/ocr2/aggregator.cairo#L260
+        // TODO: use StarknetContract decodeEvents from starknet-hardhat-plugin instead
+        const eventData = txReceipt.events[0].data
+        // reconstruct signers array from event
+        const eventSigners: bigint[] = []
+        for (let i = 0; i < signers.length; i++) {
+          const signer = BigInt(eventData[2 + 2 * i]) // split according to event structure
+          eventSigners.push(signer)
+        }
+
+        // Checks that the feed was updated
+        expect(eventSigners).toEqual(
+          // eaiser to remove prefix and 0x and then add 0x back
+          signers.map((s) => BigInt(`0x${s.replace('ocr2on_starknet_', '').replace('0x', '')}`)),
+        ) // remove all prefixes
+        expect(resultTransmitters).toEqual(transmitters.map((transmitter) => BigInt(transmitter)))
+
+        // Checks that the correct number of batch calls were made
+        expect(counter.get(feedAddress) ?? 0).toEqual(1)
+      }
+    },
+    TIMEOUT,
+  )
+
+  it(
+    'Transfer ownership using --batch',
+    async () => {
+      const command = await registerExecuteCommand(transferOwnershipCommand).create(
+        {
+          // Trivially transfer ownership to the same address
+          newOwner: owner.address,
+          batch: true,
+        },
+        feedAddresses,
+      )
+
+      // Execute the command
+      const report = await command.execute()
+      const maybeRes = report.responses.at(0)
+      expect(maybeRes).not.toBeFalsy()
+
+      // Validate the response
+      const res = maybeRes!
+      expect(res.tx.status).toEqual('ACCEPTED')
+      expect(res.tx.hash).not.toBeNull()
+
+      // Checks that the transaction was successful
+      const provider: RpcProvider = makeProvider(LOCAL_URL).provider
+      const receipt = await provider.waitForTransaction(res.tx.hash)
+      expect(receipt.isSuccess()).toBeTruthy()
+      const txReceipt = receipt as InvokeTransactionReceiptResponse
+
+      // Creates a map where each key is an address and each corresponding value is
+      // the number of times the address is seen in the transaction receipt events
+      const counter = getNumCallsPerAddress(txReceipt)
 
       // Checks that the correct number of batch calls were made
-      const invocations = receipt.events.filter((ev) => ev.from_address === contractAddress)
-      expect(invocations.length).toEqual(batchCount)
-
-      // TODO: use StarknetContract decodeEvents from starknet-hardhat-plugin instead
-      const eventData = receipt.events[0].data
-      // reconstruct signers array from event
-      const eventSigners: bigint[] = []
-      for (let i = 0; i < signers.length; i++) {
-        const signer = BigInt(eventData[2 + 2 * i]) // split according to event structure
-        eventSigners.push(signer)
+      for (const feedAddress of feedAddresses) {
+        expect(counter.get(feedAddress) ?? 0).toEqual(1)
       }
+    },
+    TIMEOUT,
+  )
 
-      expect(eventSigners).toEqual(
-        // eaiser to remove prefix and 0x and then add 0x back
-        signers.map((s) => BigInt(`0x${s.replace('ocr2on_starknet_', '').replace('0x', '')}`)),
-      ) // remove all prefixes
-      expect(resultTransmitters).toEqual(transmitters.map((transmitter) => BigInt(transmitter)))
+  it(
+    'Accept ownership using --batch',
+    async () => {
+      const command = await registerExecuteCommand(acceptOwnershipCommand).create(
+        {
+          batch: true,
+        },
+        feedAddresses,
+      )
+
+      // Execute the command
+      const report = await command.execute()
+      const maybeRes = report.responses.at(0)
+      expect(maybeRes).not.toBeFalsy()
+
+      // Validate the response
+      const res = maybeRes!
+      expect(res.tx.status).toEqual('ACCEPTED')
+      expect(res.tx.hash).not.toBeNull()
+
+      // Checks that the transaction was successful
+      const provider: RpcProvider = makeProvider(LOCAL_URL).provider
+      const receipt = await provider.waitForTransaction(res.tx.hash)
+      expect(receipt.isSuccess()).toBeTruthy()
+      const txReceipt = receipt as InvokeTransactionReceiptResponse
+
+      // Creates a map where each key is an address and each corresponding value is
+      // the number of times the address is seen in the transaction receipt events
+      const counter = getNumCallsPerAddress(txReceipt)
+
+      // Checks that the correct number of batch calls were made
+      for (const feedAddress of feedAddresses) {
+        expect(counter.get(feedAddress) ?? 0).toEqual(1)
+      }
     },
     TIMEOUT,
   )

--- a/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
+++ b/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
@@ -188,13 +188,27 @@ export const makeExecuteCommand = <UI, CI>(config: ExecuteCommandConfig<UI, CI>)
 
     // TODO: This will be required for Multisig
     makeMessage = async (): Promise<Call[]> => {
-      const contract = new Contract(this.contract.abi, this.contractAddress, this.provider.provider)
-      const invocation = contract.populate(
-        config.internalFunction || config.action,
-        this.input.contract as any,
-      )
+      const makeInvocation = (contractAddress: string) => {
+        const contract = new Contract(this.contract.abi, contractAddress, this.provider.provider)
+        return contract.populate(
+          config.internalFunction || config.action,
+          this.input.contract as any,
+        )
+      }
 
-      return [invocation]
+      // If a flag called `batch` is present and it's value is `true`,
+      // then the following assumptions will be made here:
+      //
+      //  - All `args` are valid Starknet contract addresses
+      //  - All contract addresses reference contracts with the same ABI
+      //  - All contract invocations will be populated with the same inputs
+      //
+      const batch = this.flags.batch
+      if (typeof batch === 'boolean' && batch) {
+        return this.args.map(makeInvocation)
+      }
+
+      return [makeInvocation(this.contractAddress)]
     }
 
     deployContract = async (): Promise<TransactionResponse> => {

--- a/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
+++ b/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
@@ -201,7 +201,7 @@ export const makeExecuteCommand = <UI, CI>(config: ExecuteCommandConfig<UI, CI>)
       //
       //  - All `args` are valid Starknet contract addresses
       //  - All contract addresses reference contracts with the same ABI
-      //  - All contract invocations will be populated with the same inputs
+      //  - All contract invocations should be populated with the same inputs
       //
       const batch = this.flags.batch
       if (typeof batch === 'boolean' && batch) {

--- a/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
+++ b/packages-ts/starknet-gauntlet/src/commands/base/executeCommand.ts
@@ -188,27 +188,19 @@ export const makeExecuteCommand = <UI, CI>(config: ExecuteCommandConfig<UI, CI>)
 
     // TODO: This will be required for Multisig
     makeMessage = async (): Promise<Call[]> => {
-      const makeInvocation = (contractAddress: string) => {
-        const contract = new Contract(this.contract.abi, contractAddress, this.provider.provider)
-        return contract.populate(
-          config.internalFunction || config.action,
-          this.input.contract as any,
-        )
-      }
-
-      // If a flag called `batch` is present and it's value is `true`,
-      // then the following assumptions will be made here:
+      // If more than one argument is passed in, then the following assumptions will be made:
       //
       //  - All `args` are valid Starknet contract addresses
       //  - All contract addresses reference contracts with the same ABI
       //  - All contract invocations should be populated with the same inputs
       //
-      const batch = this.flags.batch
-      if (typeof batch === 'boolean' && batch) {
-        return this.args.map(makeInvocation)
-      }
-
-      return [makeInvocation(this.contractAddress)]
+      return this.args.map((addr) => {
+        const contract = new Contract(this.contract.abi, addr, this.provider.provider)
+        return contract.populate(
+          config.internalFunction || config.action,
+          this.input.contract as any,
+        )
+      })
     }
 
     deployContract = async (): Promise<TransactionResponse> => {


### PR DESCRIPTION
# Gauntlet Batching MVP

## Context
- Batching is a necessary requirement for Starknet production mainnet support, and should be considered a blocker since it is not currently supported
- Adding support for batching to gauntlet classic could take a full sprint to complete (this includes implementation + code testing), which could lead to delays
- To reduce this risk, the proposed workaround is to add batching support to the commands that matter the most - this should take less than a sprint to complete and helps keep us on track with the launch date

## Overview of Changes
- This PR adds rudimentary batching support to `set_config`, `set_billing`, `accept_ownership`, and `transfer_ownership`, which should cover the most frequent use cases
- When multiple contract addresses are passed as arguments to an execute command, the operation will be applied to each of the contracts using a single transaction
- New test cases have been added for each of these commands as well