### PR TITLE
Removing sonar from running on merge

### DIFF
--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -1,9 +1,6 @@
 name: SonarQube Scan
 
 on:
-  push:
-    branches:
-      - develop
   pull_request:
 
 jobs:


### PR DESCRIPTION
No need to run sonar on merge.