### PR TITLE
RDD Batching

### DIFF
--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setBilling.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setBilling.ts
@@ -6,6 +6,7 @@ import {
 } from '@chainlink/starknet-gauntlet'
 import { ocr2ContractLoader } from '../../lib/contracts'
 import { SetBilling, SetBillingInput } from '@chainlink/gauntlet-contracts-ocr2'
+import { getRDD } from '@chainlink/starknet-gauntlet'
 
 type StarknetSetBillingInput = SetBillingInput & { gasBase: number; gasPerSignature: number }
 
@@ -22,11 +23,6 @@ const makeContractInput = async (
   input: StarknetSetBillingInput,
   ctx: ExecutionContext,
 ): Promise<ContractInput> => {
-  if (ctx.rdd) {
-    const contract = ctx.rdd[CONTRACT_TYPES.AGGREGATOR][ctx.contractAddress]
-    input = contract.billing
-  }
-
   return [
     {
       observation_payment_gjuels: input.observationPaymentGjuels,
@@ -41,6 +37,13 @@ const commandConfig: ExecuteCommandConfig<StarknetSetBillingInput, ContractInput
   ...SetBilling,
   makeUserInput: (flags: any, args: any): StarknetSetBillingInput => {
     if (flags.input) return flags.input as StarknetSetBillingInput
+    if (flags.rdd) {
+      const rdd = getRDD(flags.rdd)
+      const contractAddr = args[0]
+      const contract = rdd[CONTRACT_TYPES.AGGREGATOR][contractAddr]
+      return contract.billing
+    }
+
     return {
       observationPaymentGjuels: parseInt(flags.observationPaymentGjuels),
       transmissionPaymentGjuels: parseInt(flags.transmissionPaymentGjuels),

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setPayees.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setPayees.ts
@@ -26,7 +26,8 @@ const makeUserInput = async (flags, args): Promise<UserInput> => {
   if (flags.rdd) {
     const rdd = await getRDD(flags.rdd)
     const contractAddress = args[0]
-    return rdd[CONTRACT_TYPES.AGGREGATOR][contractAddress].payees
+    const contract = rdd[CONTRACT_TYPES.AGGREGATOR][contractAddress]
+    return contract.payees
   }
 
   const transmitters = flags.transmitters.split(',')

--- a/packages-ts/starknet-gauntlet-ocr2/test/commands/utils.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/test/commands/utils.ts
@@ -1,0 +1,51 @@
+import * as fsp from 'fs/promises'
+import * as fs from 'fs'
+import path from 'path'
+
+export interface BillingConfig {
+  gasBase: string
+  gasPerSignature: string
+  observationPaymentGjuels: string
+  transmissionPaymentGjuels: string
+}
+
+export class RDDTempFile {
+  private readonly contracts = new Map<
+    string,
+    {
+      billing: BillingConfig
+    }
+  >()
+
+  constructor(public readonly filepath: string) {
+    if (path.extname(filepath) !== '.json') {
+      throw new Error(`filepath must point to a json file: ${filepath}`)
+    }
+  }
+
+  getConfig() {
+    return {
+      contracts: Object.fromEntries(this.contracts.entries()),
+    }
+  }
+
+  setBilling(addr: string, data: BillingConfig) {
+    const contract = this.contracts.get(addr)
+    if (contract == null) {
+      this.contracts.set(addr, { billing: data })
+    } else {
+      this.contracts.set(addr, { ...contract, billing: data })
+    }
+  }
+
+  async writeFile() {
+    await fsp.mkdir(path.dirname(this.filepath), { recursive: true })
+    return await fsp.writeFile(this.filepath, JSON.stringify(this.getConfig(), null, 2))
+  }
+
+  async removeFile() {
+    if (fs.existsSync(this.filepath)) {
+      return await fsp.rm(this.filepath)
+    }
+  }
+}


### PR DESCRIPTION
This PR builds off the work in https://github.com/smartcontractkit/chainlink-starknet/pull/433. Consider the following Gauntlet command:

```sh
yarn gauntlet ocr2:set_billing \
  --rdd=/reference-data-directory/directory-ethereum-testnet-sepolia-starknet-1.json \
  "0x79c0bc2a03570241c27235a2dca7696a658cbdaae0bad5762e30204b2791aba" \
  "0x31b3f3475b58a55a707b5990a4328d7ac026fede2df4b0aaedca042aeb351a3"
  ...
```

There's two things to note here:
1. Multiple contract addresses are passed as input (so it is assumed we want to execute a batched call)
2. Only one RDD file can be passed to this command

In the current implementation, the Gauntlet runtime will construct one transaction with a series of `set_billing` calls (one for each input argument / address). The parameters to each call will be the same, and the RDD config values corresponding to the first input argument (in this case `0x79c0bc2a03570241c27235a2dca7696a658cbdaae0bad5762e30204b2791aba`) will be used as the parameters for each call.

This PR modifies the above behavior such that the RDD configs for each respective input address are extracted individually to each call and forwarded to the `set_billing` function. 

More generally, any execute-type commands that support the RDD flag now follow the behavior outlined above.