### PR TITLE
BCI-3349: Add latest_answer

### DIFF
--- a/contracts/src/emergency/sequencer_uptime_feed.cairo
+++ b/contracts/src/emergency/sequencer_uptime_feed.cairo
@@ -161,6 +161,13 @@ mod SequencerUptimeFeed {
         fn decimals(self: @ContractState) -> u8 {
             0_u8
         }
+
+        fn latest_answer(self: @ContractState) -> u128 {
+            self._require_read_access();
+            let latest_round_id = self._latest_round_id.read();
+            let round_transmission = self._round_transmissions.read(latest_round_id);
+            round_transmission.answer
+        }
     }
 
     #[constructor]

--- a/contracts/src/ocr2/aggregator.cairo
+++ b/contracts/src/ocr2/aggregator.cairo
@@ -63,6 +63,7 @@ trait IAggregator<TContractState> {
     fn round_data(self: @TContractState, round_id: u128) -> Round;
     fn description(self: @TContractState) -> felt252;
     fn decimals(self: @TContractState) -> u8;
+    fn latest_answer(self: @TContractState) -> u128;
 }
 
 #[derive(Copy, Drop, Serde)]
@@ -373,6 +374,13 @@ mod Aggregator {
         fn decimals(self: @ContractState) -> u8 {
             self._require_read_access();
             self._decimals.read()
+        }
+
+        fn latest_answer(self: @ContractState) -> u128 {
+            self._require_read_access();
+            let latest_round_id = self._latest_aggregator_round_id.read();
+            let transmission = self._transmissions.read(latest_round_id);
+            transmission.answer
         }
     }
 

--- a/contracts/src/ocr2/aggregator_proxy.cairo
+++ b/contracts/src/ocr2/aggregator_proxy.cairo
@@ -9,6 +9,7 @@ trait IAggregatorProxy<TContractState> {
     fn round_data(self: @TContractState, round_id: felt252) -> Round;
     fn description(self: @TContractState) -> felt252;
     fn decimals(self: @TContractState) -> u8;
+    fn latest_answer(self: @TContractState) -> u128;
 }
 
 #[starknet::interface]
@@ -151,6 +152,13 @@ mod AggregatorProxy {
             let phase = self._current_phase.read();
             let aggregator = IAggregatorDispatcher { contract_address: phase.aggregator };
             aggregator.decimals()
+        }
+
+        fn latest_answer(self: @ContractState) -> u128 {
+            self._require_read_access();
+            let phase = self._current_phase.read();
+            let aggregator = IAggregatorDispatcher { contract_address: phase.aggregator };
+            aggregator.latest_answer()
         }
     }
 

--- a/contracts/src/ocr2/mocks/mock_aggregator.cairo
+++ b/contracts/src/ocr2/mocks/mock_aggregator.cairo
@@ -117,5 +117,11 @@ mod MockAggregator {
         fn description(self: @ContractState) -> felt252 {
             'mock'
         }
+
+        fn latest_answer(self: @ContractState) -> u128 {
+            let latest_round_id = self._latest_aggregator_round_id.read();
+            let transmission = self._transmissions.read(latest_round_id);
+            transmission.answer
+        }
     }
 }

--- a/contracts/src/tests/test_aggregator_proxy.cairo
+++ b/contracts/src/tests/test_aggregator_proxy.cairo
@@ -116,6 +116,10 @@ fn test_query_latest_round_data() {
     assert(round.block_num == 1, 'block_num should be 1');
     assert(round.started_at == 9, 'started_at should be 9');
     assert(round.updated_at == 8, 'updated_at should be 8');
+
+    // latest_answer matches up with latest_round_data 
+    let latest_answer = AggregatorProxyImpl::latest_answer(@state);
+    assert(latest_answer == 10, '(latest) answer should be 10');
 }
 
 #[test]
@@ -132,6 +136,22 @@ fn test_query_latest_round_data_without_access() {
     set_caller_address(contract_address_const::<2>());
     // query latest round
     AggregatorProxyImpl::latest_round_data(@state);
+}
+
+#[test]
+#[should_panic(expected: ('user does not have read access',))]
+fn test_query_latest_answer_without_access() {
+    let (owner, mockAggregatorAddr, mockAggregator, _, _) = setup();
+    let mut state = STATE();
+    // init aggregator proxy with mock aggregator
+    AggregatorProxy::constructor(ref state, owner, mockAggregatorAddr);
+    state.add_access(owner);
+    // insert round into mock aggregator
+    mockAggregator.set_latest_round_data(10, 1, 9, 8);
+    // set caller to non-owner address with no read access
+    set_caller_address(contract_address_const::<2>());
+    // query latest round
+    AggregatorProxyImpl::latest_answer(@state);
 }
 
 #[test]

--- a/contracts/src/tests/test_mock_aggregator.cairo
+++ b/contracts/src/tests/test_mock_aggregator.cairo
@@ -57,6 +57,9 @@ fn test_set_latest_round() {
         MockAggregator::Aggregator::latest_round_data(@state) == expected_round, 'round not equal'
     );
 
-    assert(MockAggregator::Aggregator::latest_answer(@state) == expected_round.answer, 'latest answer not equal');
+    assert(
+        MockAggregator::Aggregator::latest_answer(@state) == expected_round.answer,
+        'latest answer not equal'
+    );
 }
 

--- a/contracts/src/tests/test_mock_aggregator.cairo
+++ b/contracts/src/tests/test_mock_aggregator.cairo
@@ -56,5 +56,7 @@ fn test_set_latest_round() {
     assert(
         MockAggregator::Aggregator::latest_round_data(@state) == expected_round, 'round not equal'
     );
+
+    assert(MockAggregator::Aggregator::latest_answer(@state) == expected_round.answer, 'latest answer not equal');
 }
 


### PR DESCRIPTION
The proxy and aggregator contract should have a view-only function latest_answer. This is the standard for EVM contracts and it helps simplify external adapter logic