### PR TITLE
fix signature

### DIFF
--- a/relayer/pkg/chainlink/ocr2/medianreport/report.go
+++ b/relayer/pkg/chainlink/ocr2/medianreport/report.go
@@ -76,12 +76,12 @@ func (c ReportCodec) BuildReport(oo []median.ParsedAttributedObservation) (types
 	var observers = make([]byte, starknet.FeltLength)
 	var observations []*felt.Felt
 
+	observers[0] = uint8(1)
 	for i, o := range oo {
-		// encoding scheme is offset by 1 byte to avoid felt overflow
-		// [0x0, <1_ID>, <2_ID>, ..., <N_ID>, 0x0, 0x0, ..., 0x0]
+		// encoding scheme is offset by 0x01-padded to avoid felt overflow
+		// [0x01, <1_ID>, <2_ID>, ..., <N_ID>, 0x0, 0x0, ..., 0x0]
 		// note: this does not alter Starknet's MAX_ORACLES (31)
-		// to differentiate this encoding scheme from the original encoding scheme, check if, within the first N + 1 bytes, 0 occurs twice
-		// where N is the number of oracles in the DON
+		// where N is the length of the observations array
 		observers[i+1] = byte(o.Observer)
 
 		f := starknetutils.BigIntToFelt(o.Value)

--- a/relayer/pkg/chainlink/ocr2/medianreport/report.go
+++ b/relayer/pkg/chainlink/ocr2/medianreport/report.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 
 	"github.com/NethermindEth/juno/core/felt"
+	"github.com/NethermindEth/starknet.go/curve"
 	starknetutils "github.com/NethermindEth/starknet.go/utils"
 
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
@@ -74,11 +75,22 @@ func (c ReportCodec) BuildReport(oo []median.ParsedAttributedObservation) (types
 
 	var observers = make([]byte, starknet.FeltLength)
 	var observations []*felt.Felt
+
 	for i, o := range oo {
-		observers[i] = byte(o.Observer)
+		// encoding scheme is offset by 1 byte to avoid felt overflow
+		// [0x0, <1_ID>, <2_ID>, ..., <N_ID>, 0x0, 0x0, ..., 0x0]
+		// note: this does not alter Starknet's MAX_ORACLES (31)
+		// to differentiate this encoding scheme from the original encoding scheme is to check if, within the first N + 1 bytes, 0 occurs twice
+		// where N is the number of oracles in the DON
+		observers[i+1] = byte(o.Observer)
 
 		f := starknetutils.BigIntToFelt(o.Value)
 		observations = append(observations, f)
+	}
+
+	observersBig := starknetutils.BytesToBig(observers)
+	if observersBig.Cmp(curve.Curve.P) != -1 {
+		return nil, fmt.Errorf("invalid observers value: %v is larger than size of finite field", observersBig)
 	}
 
 	var report []byte

--- a/relayer/pkg/chainlink/ocr2/medianreport/report.go
+++ b/relayer/pkg/chainlink/ocr2/medianreport/report.go
@@ -80,7 +80,7 @@ func (c ReportCodec) BuildReport(oo []median.ParsedAttributedObservation) (types
 		// encoding scheme is offset by 1 byte to avoid felt overflow
 		// [0x0, <1_ID>, <2_ID>, ..., <N_ID>, 0x0, 0x0, ..., 0x0]
 		// note: this does not alter Starknet's MAX_ORACLES (31)
-		// to differentiate this encoding scheme from the original encoding scheme is to check if, within the first N + 1 bytes, 0 occurs twice
+		// to differentiate this encoding scheme from the original encoding scheme, check if, within the first N + 1 bytes, 0 occurs twice
 		// where N is the number of oracles in the DON
 		observers[i+1] = byte(o.Observer)
 

--- a/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
+++ b/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NethermindEth/starknet.go/curve"
+	starknetutils "github.com/NethermindEth/starknet.go/utils"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -71,8 +73,15 @@ func TestBuildReportNoObserversOverflow(t *testing.T) {
 		})
 	}
 
-	_, err := c.BuildReport(oo)
+	report, err := c.BuildReport(oo)
 	assert.Nil(t, err)
+
+	index := timestampSizeBytes
+	observersBytes := []byte(report[index : index+observersSizeBytes])
+	observersBig := starknetutils.BytesToBig(observersBytes)
+
+	// encoded observers felt is less than max felt
+	assert.Equal(t, -1, observersBig.Cmp(curve.Curve.P))
 }
 
 func TestBuildReport(t *testing.T) {

--- a/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
+++ b/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
@@ -81,7 +81,7 @@ func TestBuildReportNoObserversOverflow(t *testing.T) {
 	observersBig := starknetutils.BytesToBig(observersBytes)
 
 	// encoded observers felt is less than max felt
-	assert.Equal(t, -1, observersBig.Cmp(curve.Curve.P))
+	assert.Equal(t, -1, observersBig.Cmp(curve.Curve.P), "observers should be less than max felt")
 }
 
 func TestBuildReport(t *testing.T) {

--- a/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
+++ b/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
@@ -13,6 +13,15 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 )
 
+func TestTrial(t *testing.T) {
+	val := "4077890116503514227502940569025930714369419670386493876774642852321317355520"
+	x, err := big.NewInt(0).SetString(val, 10)
+	assert.False(t, err)
+
+	res1 := x.Cmp(big.NewInt(0))
+	assert.Equal(t, -1, res1)
+}
+
 func TestBuildReportWithNegativeValues(t *testing.T) {
 	c := ReportCodec{}
 	oo := []median.ParsedAttributedObservation{}
@@ -73,7 +82,8 @@ func TestBuildReport(t *testing.T) {
 		})
 
 		// create expected outputs
-		observers[i] = uint8(i)
+		// remember to add 1 byte offset to avoid felt overflow
+		observers[i+1] = uint8(i)
 	}
 
 	report, err := c.BuildReport(oo)

--- a/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
+++ b/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
@@ -63,6 +63,8 @@ func TestBuildReport(t *testing.T) {
 	v := big.NewInt(0)
 	v.SetString("1000000000000000000", 10)
 
+	// 0x01 pad the first byte
+	observers[0] = uint8(1)
 	for i := 0; i < n; i++ {
 		oo = append(oo, median.ParsedAttributedObservation{
 			Timestamp:        uint32(time.Now().Unix()),

--- a/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
+++ b/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
@@ -13,15 +13,6 @@ import (
 	"github.com/smartcontractkit/libocr/offchainreporting2/reportingplugin/median"
 )
 
-func TestTrial(t *testing.T) {
-	val := "4077890116503514227502940569025930714369419670386493876774642852321317355520"
-	x, err := big.NewInt(0).SetString(val, 10)
-	assert.False(t, err)
-
-	res1 := x.Cmp(big.NewInt(0))
-	assert.Equal(t, -1, res1)
-}
-
 func TestBuildReportWithNegativeValues(t *testing.T) {
 	c := ReportCodec{}
 	oo := []median.ParsedAttributedObservation{}

--- a/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
+++ b/relayer/pkg/chainlink/ocr2/medianreport/report_test.go
@@ -53,6 +53,28 @@ func TestBuildReportWithNegativeValues(t *testing.T) {
 	assert.ErrorContains(t, err, "starknet does not support negative values: value = (10), fee = (10), gas = (-10)")
 }
 
+func TestBuildReportNoObserversOverflow(t *testing.T) {
+	c := ReportCodec{}
+	oo := []median.ParsedAttributedObservation{}
+	fmt.Println("hello")
+	v := big.NewInt(0)
+	v.SetString("1000000000000000000", 10)
+
+	// test largest possible encoded observers byte array
+	for i := 30; i >= 0; i-- {
+		oo = append(oo, median.ParsedAttributedObservation{
+			Timestamp:        uint32(time.Now().Unix()),
+			Value:            big.NewInt(1234567890),
+			GasPriceSubunits: big.NewInt(2),
+			JuelsPerFeeCoin:  v,
+			Observer:         commontypes.OracleID(i),
+		})
+	}
+
+	_, err := c.BuildReport(oo)
+	assert.Nil(t, err)
+}
+
 func TestBuildReport(t *testing.T) {
 	c := ReportCodec{}
 	oo := []median.ParsedAttributedObservation{}


### PR DESCRIPTION
### Background
Observers array is a big-endian array with the oracle id (0...N-1) of the oracle that made the corresponding observation in the observation array. So [0x4, 0x1, 0x3, 0x0, 0x2, 0x0, ... , 0x0] shows the observations were given in the order of oracles with ids 4, 1, 3, 0, 2 (given 5 oracles). The rest of the byte array is 0x0 because there are only 5 oracles

### Problem
There was a small bug where if the first byte (big-endian) is 0x8 (oracle-id 8) or higher, the observers byte will cause felt overflow.

this happens 1/8 * (N - 8) where N is the total number of oracles we have.

it does not affect feed uptime because if it occurs, the current round will fail and a new round will be kicked off after and succeed, but it is a serialization error that needs to be fixed bc it causes rounds to fail.

### Solution
the fix is to 0x01-pad the first byte (big-endian) so that the new byte array represents at most `2^249 - 1` values which is definitely less than https://docs.starknet.io/architecture-and-concepts/cryptography/p-value/

### Deserializing
If you are reading observers on-chain, to differentiate this new encoding scheme from the original encoding scheme, check if, within the first N + 1 bytes (where N is the length of the observations array), 0x01 occurs twice, once at the 0th index and at index 1 to N.

^ the above is only really necessary during the blocks in which chainlink nodes are being upgraded

In the event that oracle id 1 has not reported, technically you cannot differentiate between the two cases so you can fallback to the new encoding scheme. Should not be an issue because the window for the upgrade will be small so and presumably after some block number you can always be sure it is using the new encoding scheme