### PR TITLE
BCI-3889: use pending block

### DIFF
--- a/relayer/pkg/starknet/client.go
+++ b/relayer/pkg/starknet/client.go
@@ -92,7 +92,7 @@ func (c *Client) CallContract(ctx context.Context, ops CallOps) (data []*felt.Fe
 		Calldata:           ops.Calldata,
 	}
 
-	res, err := c.Call(ctx, tx, starknetrpc.WithBlockTag("latest"))
+	res, err := c.Call(ctx, tx, starknetrpc.WithBlockTag("pending"))
 	if err != nil {
 		return nil, fmt.Errorf("error in client.CallContract: %w", err)
 	}


### PR DESCRIPTION
Pending blocks contain finalized txs, so we should be reading pending blocks to read the latest finalized transactions. 

This should also mitigate current behavior where we are seeing stale reports (ending in an on-chain revert or a fee-estimation failure) because nodes keep on transmitting the same report because they are reading the latest block and assuming it didn't make it on chain.