### PR TITLE
BCI-3898: fix multisig set config bug

### DIFF
--- a/packages-ts/starknet-gauntlet-cli/src/index.ts
+++ b/packages-ts/starknet-gauntlet-cli/src/index.ts
@@ -64,6 +64,7 @@ const registerExecuteCommand = <UI, CI>(
         billingAccessController: process.env.BILLING_ACCESS_CONTROLLER,
         link: process.env.LINK,
         secret: flags.secret || process.env.SECRET,
+        randomSecret: flags.randomSecret || process.env.RANDOM_SECRET,
         withLedger: !!flags.withLedger || !!process.env.WITH_LEDGER,
         ledgerPath: (flags.ledgerPath as string) || process.env.LEDGER_PATH,
       }

--- a/packages-ts/starknet-gauntlet-multisig/test/multisig/test.ts
+++ b/packages-ts/starknet-gauntlet-multisig/test/multisig/test.ts
@@ -1,9 +1,0 @@
-import { shortString } from 'starknet'
-
-const strings = shortString.splitLongString(
-  '0x0000000000004163636f756e743a20696e76616c6964207369676e6174757265',
-)
-console.log(strings)
-strings.forEach((s) => {
-  shortString.decodeShortString(s)
-})

--- a/packages-ts/starknet-gauntlet-multisig/test/multisig/test.ts
+++ b/packages-ts/starknet-gauntlet-multisig/test/multisig/test.ts
@@ -1,0 +1,9 @@
+import { shortString } from 'starknet'
+
+const strings = shortString.splitLongString(
+  '0x0000000000004163636f756e743a20696e76616c6964207369676e6174757265',
+)
+console.log(strings)
+strings.forEach((s) => {
+  shortString.decodeShortString(s)
+})

--- a/packages-ts/starknet-gauntlet-ocr2/README.md
+++ b/packages-ts/starknet-gauntlet-ocr2/README.md
@@ -69,6 +69,8 @@ Run the following command substituting <OCR_CONTRACT_ADDRESS> with the OCR2 cont
 yarn gauntlet ocr2:set_config --network=<NETWORK> --address=<ADDRESS> --f=<NUMBER> --signers=[<ACCOUNTS>] --transmitters=[<ACCOUNTS>] --onchainConfig=<CONFIG> --offchainConfig=<CONFIG> --offchainConfigVersion=<NUMBER> <OCR_CONTRACT_ADDRESS>
 ```
 
+Note: You need to include both a secret and a random secret to deterministically run the set config (2 different secrets). They can be provided as environment variables or flags
+
 This Should set the config for this feed on contract address.
 
 

--- a/packages-ts/starknet-gauntlet-ocr2/README.md
+++ b/packages-ts/starknet-gauntlet-ocr2/README.md
@@ -66,10 +66,10 @@ This Should set the billing details for this feed on contract address
 Run the following command substituting <OCR_CONTRACT_ADDRESS> with the OCR2 contract address you received in the deploy step:
 
 ```
-yarn gauntlet ocr2:set_config --network=<NETWORK> --address=<ADDRESS> --f=<NUMBER> --signers=[<ACCOUNTS>] --transmitters=[<ACCOUNTS>] --onchainConfig=<CONFIG> --offchainConfig=<CONFIG> --offchainConfigVersion=<NUMBER> <OCR_CONTRACT_ADDRESS>
+yarn gauntlet ocr2:set_config --network=<NETWORK> --address=<ADDRESS> --secret=<SECRET> --f=<NUMBER> --signers=[<ACCOUNTS>] --transmitters=[<ACCOUNTS>] --onchainConfig=<CONFIG> --offchainConfig=<CONFIG> --offchainConfigVersion=<NUMBER> <OCR_CONTRACT_ADDRESS>
 ```
 
-Note: You need to include both a secret and a random secret to deterministically run the set config (2 different secrets). They can be provided as environment variables or flags
+Note: You must include the same random secret to deterministically run the set config multiple times (ex: for multisig proposals among different signers signing the same transaction). This can be achieved by setting a flag or environment variable ``--randomSecret`` or ``RANDOM_SECRET`` respectiviely. 
 
 This Should set the config for this feed on contract address.
 

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
@@ -98,11 +98,6 @@ const makeUserInput = async (flags, args, env): Promise<SetConfigInput> => {
 }
 
 export const validateSecretsNotEmpty = async (input) => {
-  if (input.randomSecret === undefined) {
-    throw new Error(
-      `A random secret must be provided (--randomSecret flag or RANDOM_SECRET environment variable)`,
-    )
-  }
 
   if (input.secret === undefined) {
     throw new Error(`A secret must be provided (--secret flag or SECRET environment variable)`)

--- a/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/commands/ocr2/setConfig.ts
@@ -98,7 +98,6 @@ const makeUserInput = async (flags, args, env): Promise<SetConfigInput> => {
 }
 
 export const validateSecretsNotEmpty = async (input) => {
-
   if (input.secret === undefined) {
     throw new Error(`A secret must be provided (--secret flag or SECRET environment variable)`)
   }

--- a/packages-ts/starknet-gauntlet-ocr2/src/lib/utils.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/src/lib/utils.ts
@@ -1,8 +1,4 @@
-import {
-  ExecuteCommandConfig,
-  makeExecuteCommand,
-  isValidAddress,
-} from '@chainlink/starknet-gauntlet'
+import { isValidAddress } from '@chainlink/starknet-gauntlet'
 
 export const validateClassHash = async (input) => {
   if (isValidAddress(input.classHash) || input.classHash === undefined) {

--- a/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
+++ b/packages-ts/starknet-gauntlet-ocr2/test/commands/ocr2.test.ts
@@ -73,6 +73,7 @@ const validInput = {
   },
   offchainConfigVersion: 2,
   secret: 'awe accuse polygon tonic depart acuity onyx inform bound gilbert expire',
+  randomSecret: 'awe accuse polygon tonic depart acuity onyx inform bound gilbert expire',
 }
 
 const getNumCallsPerAddress = (txReceipt: InvokeTransactionReceiptResponse) => {

--- a/packages-ts/starknet-gauntlet/src/utils/configDigest.ts
+++ b/packages-ts/starknet-gauntlet/src/utils/configDigest.ts
@@ -1,0 +1,25 @@
+import fs from 'fs'
+import { CONTRACT_TYPES, getRDD } from '../rdd'
+import { Dependencies } from '../dependencies'
+
+export const tryToWriteLastConfigDigestToRDD = async (
+  deps: Pick<Dependencies, 'logger' | 'prompt'>,
+  rddPath: string,
+  contractAddr: string,
+  configDigest: string,
+) => {
+  deps.logger.info(`lastConfigDigest to save in RDD: ${configDigest}`)
+  if (rddPath) {
+    const rdd = getRDD(rddPath)
+    // set updated lastConfigDigest
+    rdd[CONTRACT_TYPES.AGGREGATOR][contractAddr]['config']['lastConfigDigest'] = configDigest
+    fs.writeFileSync(rddPath, JSON.stringify(rdd, null, 2))
+    deps.logger.success(
+      `RDD file ${rddPath} has been updated! You must reformat RDD by running ./bin/degenerate and ./bin/generate in that exact order`,
+    )
+  } else {
+    deps.logger.warn(
+      `No RDD file was inputted, you must manually update lastConfigDigest in RDD yourself`,
+    )
+  }
+}

--- a/packages-ts/starknet-gauntlet/src/utils/index.ts
+++ b/packages-ts/starknet-gauntlet/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './address'
+export * from './configDigest'


### PR DESCRIPTION
Two bugs related to multisig set config detailed here 

https://smartcontract-it.atlassian.net/browse/BCI-3898

Changes:
* You now need to pass in --randomSecret as a flag or an enviornment variable (RANDOM_SECRET) to call ocr2:set_config
* Wrapped multisig commands will write the config digest to RDD now if the underlying call is to set_config


Commands were verified on testnet