### PR TITLE
stop giving false signal to transmit 

### DIFF
--- a/relayer/pkg/chainlink/ocr2/contract_reader.go
+++ b/relayer/pkg/chainlink/ocr2/contract_reader.go
@@ -116,8 +116,8 @@ func (c *contractReader) LatestRoundRequested(
 	}
 
 	configDigest = transmissionDetails.Digest
-	epoch = transmissionDetails.Epoch
-	round = transmissionDetails.Round
+	epoch = 0
+	round = 0
 
 	return
 }


### PR DESCRIPTION
There's a bug where we are transmitting too frequently. This discovery came as an investigation into why we were over-transmitting even when the deviation threshold was not met. It happens because the LatestRoundRequested shouldn't be triggered on Starknet.

refer to: https://github.com/smartcontractkit/libocr/blob/master/offchainreporting/internal/protocol/report_generation_follower.go#L499 (libocr)
https://github.com/smartcontractkit/chainlink-solana/blob/02a42e04dc42d30a41f07dd100cf1062e0c04a16/pkg/solana/median_contract.go#L64 (how solana deals with it)