### PR TITLE
change constructor MCMS

### DIFF
--- a/contracts/src/mcms.cairo
+++ b/contracts/src/mcms.cairo
@@ -284,11 +284,9 @@ mod ManyChainMultiSig {
     }
 
     #[constructor]
-    fn constructor(ref self: ContractState) {
-        let caller = starknet::info::get_caller_address();
-        self.ownable.initializer(caller);
+    fn constructor(ref self: ContractState, owner: ContractAddress) {
+        self.ownable.initializer(owner);
     }
-
 
     #[abi(embed_v0)]
     impl ManyChainMultiSigImpl of super::IManyChainMultiSig<ContractState> {

--- a/contracts/src/tests/test_mcms/test_set_config.cairo
+++ b/contracts/src/tests/test_mcms/test_set_config.cairo
@@ -464,11 +464,13 @@ fn test_set_config_success_dont_clear_root() {
 
     // mock the contract state
     let test_address = test_address();
-    start_cheat_caller_address(test_address, contract_address_const::<777>());
+
+    let owner = contract_address_const::<1231231111>();
+    start_cheat_caller_address(test_address, owner);
 
     // test internal function state
     let mut state = contract_state_for_testing();
-    ManyChainMultiSig::constructor(ref state);
+    ManyChainMultiSig::constructor(ref state, owner);
     state
         .set_config(
             signer_addresses.span(),
@@ -540,11 +542,14 @@ fn test_set_config_success_and_clear_root() {
     // mock the contract state
     let test_address = test_address();
     let mock_chain_id = 990;
-    start_cheat_caller_address(test_address, contract_address_const::<777>());
+
+    let owner = contract_address_const::<1231231111>();
+    start_cheat_caller_address(test_address, owner);
     start_cheat_chain_id(test_address, mock_chain_id);
 
     let mut state = contract_state_for_testing();
-    ManyChainMultiSig::constructor(ref state);
+
+    ManyChainMultiSig::constructor(ref state, owner);
 
     // initialize s_expiring_root_and_op_count & s_root_metadata
     state

--- a/contracts/src/tests/test_mcms/utils.cairo
+++ b/contracts/src/tests/test_mcms/utils.cairo
@@ -298,7 +298,10 @@ fn set_root_args(
 fn setup_mcms_deploy() -> (
     ContractAddress, IManyChainMultiSigDispatcher, IManyChainMultiSigSafeDispatcher
 ) {
-    let calldata = array![];
+    let owner = contract_address_const::<213123123>();
+    start_cheat_caller_address_global(owner);
+
+    let calldata = array![owner.into()];
 
     let (mcms_address, _) = declare("ManyChainMultiSig").unwrap().deploy(@calldata).unwrap();
 


### PR DESCRIPTION
Due to the https://docs.starknet.io/documentation/architecture_and_concepts/Smart_Contracts/universal-deployer/, the caller of the constructor is always going to be the UDC contract.

Therefore if we want the deployer account of the contract to be the owner we need to supply it through user-defined arguments in the constructor