### PR TITLE
fix metadata encoding

### DIFF
--- a/contracts/src/mcms.cairo
+++ b/contracts/src/mcms.cairo
@@ -142,10 +142,9 @@ const MANY_CHAIN_MULTI_SIG_DOMAIN_SEPARATOR_OP: u256 =
 const MANY_CHAIN_MULTI_SIG_DOMAIN_SEPARATOR_METADATA: u256 =
     0xe6b82be989101b4eb519770114b997b97b3c8707515286748a871717f0e4ea1c;
 
-fn hash_metadata(metadata: RootMetadata, valid_until: u32) -> u256 {
+fn hash_metadata(metadata: RootMetadata) -> u256 {
     let encoded_metadata: Bytes = BytesTrait::new_empty()
         .encode(MANY_CHAIN_MULTI_SIG_DOMAIN_SEPARATOR_METADATA)
-        .encode(valid_until)
         .encode(metadata.chain_id)
         .encode(metadata.multisig)
         .encode(metadata.pre_op_count)
@@ -347,7 +346,7 @@ mod ManyChainMultiSig {
             );
 
             // verify metadataProof
-            let hashed_metadata_leaf = hash_metadata(metadata, valid_until);
+            let hashed_metadata_leaf = hash_metadata(metadata);
             assert(
                 verify_merkle_proof(metadata_proof, root, hashed_metadata_leaf),
                 'proof verification failed'

--- a/contracts/src/tests/test_mcms/test_set_root.cairo
+++ b/contracts/src/tests/test_mcms/test_set_root.cairo
@@ -126,7 +126,7 @@ fn setup_mcms_deploy_set_config_and_set_root_WRONG_MULTISIG() -> (
     let op1_hash = hash_op(op1);
     let op2_hash = hash_op(op2);
 
-    let metadata_hash = hash_metadata(metadata, valid_until);
+    let metadata_hash = hash_metadata(metadata);
 
     // create merkle tree
     let (root, metadata_proof, ops_proof) = merkle_root(array![op1_hash, op2_hash, metadata_hash]);

--- a/contracts/src/tests/test_mcms/utils.cairo
+++ b/contracts/src/tests/test_mcms/utils.cairo
@@ -264,7 +264,7 @@ fn set_root_args(
     let op1_hash = hash_op(op1);
     let op2_hash = hash_op(op2);
 
-    let metadata_hash = hash_metadata(metadata, valid_until);
+    let metadata_hash = hash_metadata(metadata);
 
     // create merkle tree
     let (root, metadata_proof, ops_proof) = merkle_root(array![op1_hash, op2_hash, metadata_hash]);


### PR DESCRIPTION
valid_until is not needed for the metadata encoding. including it was an oversight (see: https://github.com/smartcontractkit/ccip-owner-contracts/blob/main/src/ManyChainMultiSig.sol#L266)

valid_until is only needed to encode the root at the very end (which is done in the contract). So effectively, before, the contract was "double-encoding" the valid_until 