### PR TITLE
fix typo README.md

### DIFF
--- a/packages-ts/starknet-gauntlet-cli/README.md
+++ b/packages-ts/starknet-gauntlet-cli/README.md
@@ -36,4 +36,4 @@ yarn gauntlet -h
 yarn gauntlet ocr2:deploy -h
 ```
 
-It will show details for the specificed function with their needed parameters and their types, if any
+It will show details for the specified function with their needed parameters and their types, if any


### PR DESCRIPTION
Corrected the typo in `packages-ts/starknet-gauntlet-cli/README.md`, changing **"specificed"** to **"specified"** for proper spelling.