### PR TITLE
fix: fix syntax error caused by extra semicolon

### DIFF
--- a/scripts/devnet.sh
+++ b/scripts/devnet.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 cpu_struct="linux";
 
 # Clean up first
-bash "$(dirname -- "$0";)/devnet.down.sh"
+bash "$(dirname -- "$0")/devnet.down.sh"
 
 echo "Checking CPU structure..."
 if [[ $cpu_struct == *"arm"* ]]


### PR DESCRIPTION
Noticed that `$(dirname -- "$0";)` contains an unnecessary semicolon, which results in a syntax error.
Removed it to ensure correct execution.