### PR TITLE
chore: Improve variable checks for empty and uninitialized values

### DIFF
--- a/scripts/generate-codegraph.sh
+++ b/scripts/generate-codegraph.sh
@@ -29,18 +29,18 @@ while getopts $options option; do
   esac
 done
 
-if [ ! "$GO_MODULE_PATH" ]; 
+if [ -z "$GO_MODULE_PATH" ]; 
 then
   echo "-p argument must be provided"
   echo "$usage" >&2; exit 1
 fi
 
-if [ ! "$OUTPUT_PNG_PATH" ]; 
+if [ -z "$OUTPUT_PNG_PATH" ]; 
 then
   OUTPUT_PNG_PATH="./godepgraph.png"
 fi
 
-if [ ! "$ALL_DEPENDENCIES" ]; 
+if [ -z "$ALL_DEPENDENCIES" ]; 
 then
   godepgraph -s -o .,github.com/smartcontractkit $GO_MODULE_PATH | dot -Tpng -o $OUTPUT_PNG_PATH
 else 


### PR DESCRIPTION
I updated the checks for the variables to ensure that they also cover empty strings and uninitialized variables. The previous condition only checked for unset variables, so it could have missed cases where the variable is set but empty. Replaced `if [ ! "$VAR" ];` with `if [ -z "$VAR" ];` for better reliability.

This should prevent any false negatives in variable validation.