### PR TITLE
Prevent nonce gaps for untracked transactions

### DIFF
--- a/relayer/pkg/chainlink/txm/txm.go
+++ b/relayer/pkg/chainlink/txm/txm.go
@@ -188,7 +188,7 @@ func (txm *starktxm) broadcast(ctx context.Context, publicKey *felt.Felt, accoun
 		if accountNonceErr != nil {
 			return txhash, fmt.Errorf("failed to check account nonce during TxStore creation: %+w", accountNonceErr)
 		}
-		newTxStore, createErr := txm.accountStore.CreateTxStore(accountAddress, initialNonce)
+		newTxStore, createErr := txm.accountStore.CreateTxStore(accountAddress, initialNonce, txm.lggr)
 		if createErr != nil {
 			return txhash, fmt.Errorf("failed to create TxStore: %+w", createErr)
 		}
@@ -362,58 +362,47 @@ func (txm *starktxm) confirmLoop() {
 				break
 			}
 
-			allUnconfirmedTxs := txm.accountStore.GetAllUnconfirmed()
-			for accountAddressStr, unconfirmedTxs := range allUnconfirmedTxs {
+			for _, accountAddressStr := range txm.accountStore.Accounts() {
 				accountAddress, err := new(felt.Felt).SetString(accountAddressStr)
 				// this should never occur because the acccount address string key was created from the account address felt.
 				if err != nil {
 					txm.lggr.Errorw("could not recreate account address felt", "accountAddress", accountAddressStr)
 					continue
 				}
-				for _, unconfirmedTx := range unconfirmedTxs {
-					hash := unconfirmedTx.Hash
-					f, err := starknetutils.HexToFelt(hash)
+				nonce, err := client.AccountNonceLatest(ctx, accountAddress)
+				if err != nil {
+					txm.lggr.Errorf("failed to fetch latest nonce for account %v", accountAddress)
+					continue
+				}
+				// Confirm all transactions with nonce lower than the latest. If it exists, get the unconfirmed transaction
+				// with a nonce equal to the latest and check if it got rejected. If it did, trigger a resyncNode to fill the
+				// nonce gap.
+				txHash := txm.accountStore.GetTxStore(accountAddress).Confirm(nonce)
+				if txHash != nil {
+					f, err := starknetutils.HexToFelt(*txHash)
 					if err != nil {
-						txm.lggr.Errorw("invalid felt value", "hash", hash)
+						txm.lggr.Errorw("invalid felt value", "hash", *txHash)
 						continue
 					}
 					response, err := client.Provider.GetTransactionStatus(ctx, f)
-
-					// tx can be rejected due to a nonce error. but we cannot know from the Starknet RPC directly  so we have to wait for
-					// a broadcasted tx to fail in order to fix the nonce errors
-
 					if err != nil {
-						txm.lggr.Errorw("failed to fetch transaction status", "hash", hash, "nonce", unconfirmedTx.Nonce, "error", err)
+						txm.lggr.Errorw("failed to fetch transaction status", "hash", txHash, "nonce", nonce, "error", err)
 						continue
 					}
-
-					finalityStatus := response.FinalityStatus
-					executionStatus := response.ExecutionStatus
-
-					// any finalityStatus other than received
-					if finalityStatus == starknetrpc.TxnStatus_Accepted_On_L1 || finalityStatus == starknetrpc.TxnStatus_Accepted_On_L2 || finalityStatus == starknetrpc.TxnStatus_Rejected {
-						txm.lggr.Debugw(fmt.Sprintf("tx confirmed: %s", finalityStatus), "hash", hash, "nonce", unconfirmedTx.Nonce, "finalityStatus", finalityStatus)
-						if err := txm.accountStore.GetTxStore(accountAddress).Confirm(unconfirmedTx.Nonce, hash); err != nil {
-							txm.lggr.Errorw("failed to confirm tx in TxStore", "hash", hash, "accountAddress", accountAddress, "error", err)
-						}
-					}
-
 					// currently, feeder client is only way to get rejected reason
-					if finalityStatus == starknetrpc.TxnStatus_Rejected {
+					if response.FinalityStatus == starknetrpc.TxnStatus_Rejected {
 						// we assume that all rejected transactions results in a unused rejected nonce, so
 						// resync. see the comment at resyncNonce for more details.
 						if resyncErr := txm.resyncNonce(ctx, client, accountAddress); resyncErr != nil {
 							txm.lggr.Errorw("resync failed for rejected tx", "error", resyncErr)
 						}
 
-						go txm.logFeederError(ctx, hash, f)
+						go txm.logFeederError(ctx, *txHash, f)
 					}
 
-					if executionStatus == starknetrpc.TxnExecutionStatusREVERTED {
-						// TODO: get revert reason?
-						txm.lggr.Errorw("transaction reverted", "hash", hash)
-					}
 				}
+				txm.lggr.Info()
+
 			}
 		case <-txm.stop:
 			txm.lggr.Debugw("confirmLoop: stopped")
@@ -458,7 +447,7 @@ func (txm *starktxm) resyncNonce(ctx context.Context, client *starknet.Client, a
 	   behind, and we fast forward. this ensures our locally tracked value will also eventually be correct.
 	*/
 
-	rpcNonce, err := client.AccountNonce(ctx, accountAddress)
+	rpcNonce, err := client.AccountNonceLatest(ctx, accountAddress)
 	if err != nil {
 		return fmt.Errorf("failed to check nonce during resync: %+w", err)
 	}

--- a/relayer/pkg/chainlink/txm/txm.go
+++ b/relayer/pkg/chainlink/txm/txm.go
@@ -23,7 +23,8 @@ import (
 )
 
 const (
-	MaxQueueLen = 1000
+	MaxQueueLen           = 1000
+	ConfirmationThreshold = 4
 )
 
 type TxManager interface {
@@ -273,7 +274,7 @@ func (txm *starktxm) broadcast(ctx context.Context, publicKey *felt.Felt, accoun
 	broadcastTxnV3.InvokeTxnV3.ResourceBounds.L1Gas.MaxPricePerUnit = txm.updateMaxPriceUnitBounds(L1GasPrice, 150)
 	broadcastTxnV3.InvokeTxnV3.ResourceBounds.L2Gas.MaxPricePerUnit = txm.updateMaxPriceUnitBounds(L2GasPrice, 150)
 
-	txm.lggr.Infow("Set resource bounds", "L1MaxAmount", tx.ResourceBounds.L1Gas.MaxAmount, "L1MaxPricePerUnit", tx.ResourceBounds.L1Gas.MaxPricePerUnit)
+	txm.lggr.Infow("Set resource bounds", "L1MaxAmount", tx.ResourceBounds.L1Gas.MaxAmount, "L1MaxPricePerUnit", tx.ResourceBounds.L1Gas.MaxPricePerUnit, "FinalNonce", nonce)
 
 	L1DataGasConsumed := friEstimate.L1DataGasConsumed.BigInt(new(big.Int))
 	L1DataGasPrice := friEstimate.L1DataGasPrice.BigInt(new(big.Int))
@@ -293,17 +294,8 @@ func (txm *starktxm) broadcast(ctx context.Context, publicKey *felt.Felt, accoun
 	// finally, transmit the invoke
 	res, err := account.Provider.AddInvokeTransaction(execCtx, &broadcastTxnV3)
 	if err != nil {
-		// TODO: handle initial broadcast errors - what kind of errors occur?
-		var dataErr *starknetrpc.RPCError
-		var dataStr string
-		if !errors.As(err, &dataErr) {
-			return txhash, fmt.Errorf("failed to read EstimateFee error: %T %+v", err, err)
-		}
-		data := dataErr.Data
-		dataStr = fmt.Sprintf("%+v", data)
-		txm.lggr.Errorw("failed to invoke tx", "accountAddress", accountAddress, "error", err, "data", dataStr)
-
-		if strings.Contains(dataStr, RPCNonceErrMsg) {
+		txm.lggr.Errorw("failed to invoke tx", "accountAddress", accountAddress, "error", err)
+		if strings.Contains(err.Error(), RPCNonceErrMsg) {
 			// if we see an invalid nonce error at the broadcast stage, that means that we are out of sync.
 			// see the comment at resyncNonce for more details.
 			if resyncErr := txm.resyncNonce(ctx, client, accountAddress); resyncErr != nil {
@@ -374,35 +366,23 @@ func (txm *starktxm) confirmLoop() {
 					txm.lggr.Errorf("failed to fetch latest nonce for account %v", accountAddress)
 					continue
 				}
-				// Confirm all transactions with nonce lower than the latest. If it exists, get the unconfirmed transaction
-				// with a nonce equal to the latest and check if it got rejected. If it did, trigger a resyncNode to fill the
-				// nonce gap.
-				txHash := txm.accountStore.GetTxStore(accountAddress).Confirm(nonce)
-				if txHash != nil {
-					f, err := starknetutils.HexToFelt(*txHash)
-					if err != nil {
-						txm.lggr.Errorw("invalid felt value", "hash", *txHash)
-						continue
-					}
-					response, err := client.Provider.GetTransactionStatus(ctx, f)
-					if err != nil {
-						txm.lggr.Errorw("failed to fetch transaction status", "hash", txHash, "nonce", nonce, "error", err)
-						continue
-					}
-					// currently, feeder client is only way to get rejected reason
-					if response.FinalityStatus == starknetrpc.TxnStatus_Rejected {
-						// we assume that all rejected transactions results in a unused rejected nonce, so
-						// resync. see the comment at resyncNonce for more details.
-						if resyncErr := txm.resyncNonce(ctx, client, accountAddress); resyncErr != nil {
-							txm.lggr.Errorw("resync failed for rejected tx", "error", resyncErr)
-						}
+				// Confirm all transactions with nonce lower than the latest.
+				confirmed, highestUnconfirmed := txm.accountStore.GetTxStore(accountAddress).Confirm(nonce)
+				txm.lggr.Infow("Confirmation loop", "latestNonce", nonce, "transactionsConfirmed", confirmed, "highestUnconfirmed", highestUnconfirmed)
 
-						go txm.logFeederError(ctx, *txHash, f)
+				// We add a maximum threshold between latest nonce and highest unconfirmed. This prevents the TXM from sending a very large
+				// number of unconfirmed transactions in the mempool and triggers a resync to prevent nonce gaps since the RPC responses are unreliable.
+				// The nonce stored here won't necessarily be picked up by the next transaction since there is a fast-forward functionality in broadcasting.
+				// But it ensures that if for whatever reason the diff between mined and uncofirmed transactions starts to grow, the TXM will be able to
+				// go back on the nonce and fill any nonce gaps.
+				hu := highestUnconfirmed.BigInt(new(big.Int))
+				n := nonce.BigInt(new(big.Int))
+				threshold := big.NewInt(ConfirmationThreshold)
+				if new(big.Int).Sub(hu, n).Cmp(threshold) == 1 {
+					if resyncErr := txm.resyncNonce(ctx, client, accountAddress); resyncErr != nil {
+						txm.lggr.Errorw("resync failed for rejected tx", "error", resyncErr)
 					}
-
 				}
-				txm.lggr.Info()
-
 			}
 		case <-txm.stop:
 			txm.lggr.Debugw("confirmLoop: stopped")
@@ -411,22 +391,6 @@ func (txm *starktxm) confirmLoop() {
 		t := txm.cfg.ConfirmationPoll() - time.Since(start)
 		tick = time.After(utils.WithJitter(t.Abs()))
 	}
-}
-
-func (txm *starktxm) logFeederError(ctx context.Context, hash string, f *felt.Felt) {
-	feederClient, err := txm.feederClient.Get()
-	if err != nil {
-		txm.lggr.Errorw("failed to load feeder client", "error", err)
-		return
-	}
-
-	rejectedTx, err := feederClient.TransactionFailure(ctx, f)
-	if err != nil {
-		txm.lggr.Errorw("failed to fetch reason for transaction failure", "hash", hash, "error", err)
-		return
-	}
-
-	txm.lggr.Errorw("feeder rejected reason", "hash", hash, "errorMessage", rejectedTx.ErrorMessage)
 }
 
 func (txm *starktxm) resyncNonce(ctx context.Context, client *starknet.Client, accountAddress *felt.Felt) error {
@@ -447,7 +411,7 @@ func (txm *starktxm) resyncNonce(ctx context.Context, client *starknet.Client, a
 	   behind, and we fast forward. this ensures our locally tracked value will also eventually be correct.
 	*/
 
-	rpcNonce, err := client.AccountNonceLatest(ctx, accountAddress)
+	rpcNonce, err := client.AccountNonce(ctx, accountAddress)
 	if err != nil {
 		return fmt.Errorf("failed to check nonce during resync: %+w", err)
 	}

--- a/relayer/pkg/chainlink/txm/txm.go
+++ b/relayer/pkg/chainlink/txm/txm.go
@@ -363,12 +363,13 @@ func (txm *starktxm) confirmLoop() {
 				}
 				nonce, err := client.AccountNonceLatest(ctx, accountAddress)
 				if err != nil {
-					txm.lggr.Errorf("failed to fetch latest nonce for account %v", accountAddress)
+					txm.lggr.Errorf("failed to fetch latest nonce for account %v, err: %v", accountAddress, err)
 					continue
 				}
 				// Confirm all transactions with nonce lower than the latest.
 				confirmed, highestUnconfirmed := txm.accountStore.GetTxStore(accountAddress).Confirm(nonce)
-				txm.lggr.Infow("Confirmation loop", "latestNonce", nonce, "transactionsConfirmed", confirmed, "highestUnconfirmed", highestUnconfirmed)
+				txm.lggr.Infow("Confirmation loop", "accountAddress", accountAddress, "latestNonce", nonce,
+					"transactionsConfirmed", confirmed, "highestUnconfirmed", highestUnconfirmed)
 
 				// We add a maximum threshold between latest nonce and highest unconfirmed. This prevents the TXM from sending a very large
 				// number of unconfirmed transactions in the mempool and triggers a resync to prevent nonce gaps since the RPC responses are unreliable.

--- a/relayer/pkg/chainlink/txm/txm_test.go
+++ b/relayer/pkg/chainlink/txm/txm_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/NethermindEth/juno/core/felt"
 	"github.com/NethermindEth/starknet.go/curve"
 	"github.com/NethermindEth/starknet.go/devnet"
 	starknetrpc "github.com/NethermindEth/starknet.go/rpc"
@@ -27,7 +28,7 @@ import (
 
 func TestIntegration_Txm(t *testing.T) {
 	ctx := t.Context()
-	n := 2 // number of txs per key
+	var nTransactions uint64 = 2 // Number of txs per key. If you increase that you might have to increase the confirmation timeout
 	// url := SetupLocalStarknetNode(t)
 	url := "http://127.0.0.1:5050"
 	devnet := devnet.NewDevNet(url)
@@ -59,7 +60,7 @@ func TestIntegration_Txm(t *testing.T) {
 	})
 	ksAdapter := NewKeystoreAdapter(looppKs)
 
-	lggr, observer := logger.TestObserved(t, zapcore.DebugLevel)
+	lggr, _ := logger.TestObserved(t, zapcore.DebugLevel)
 	timeout := 10 * time.Second
 	client, err := starknet.NewClient("SN_SEPOLIA", url+"/rpc", "", lggr, &timeout)
 	require.NoError(t, err)
@@ -86,8 +87,8 @@ func TestIntegration_Txm(t *testing.T) {
 	// start txm + checks
 	require.NoError(t, txm.Start(context.Background()))
 	require.NoError(t, txm.Ready())
-	fmt.Println("sss")
 
+	accountAddresses := make(map[*felt.Felt]*felt.Felt) // address -> latestNonce
 	for publicKeyStr := range localKeys {
 		publicKey, err := starknetutils.HexToFelt(publicKeyStr)
 		require.NoError(t, err)
@@ -95,38 +96,38 @@ func TestIntegration_Txm(t *testing.T) {
 		accountAddress, err := starknetutils.HexToFelt(localKeys[publicKeyStr].Account)
 		require.NoError(t, err)
 
+		c, err := getClient()
+		require.NoError(t, err)
+		latestNonce, err := c.AccountNonceLatest(ctx, accountAddress)
+		require.NoError(t, err)
+		accountAddresses[accountAddress] = latestNonce
+
 		contractAddress, err := starknetutils.HexToFelt("0x49D36570D4E46F48E99674BD3FCC84644DDD6B96F7C741B1562B82F9E004DC7")
 		require.NoError(t, err)
 
 		selector := starknetutils.GetSelectorFromNameFelt("totalSupply")
 
-		for i := 0; i < n; i++ {
+		for range nTransactions {
 			require.NoError(t, txm.Enqueue(ctx, accountAddress, publicKey, starknetrpc.FunctionCall{
 				ContractAddress:    contractAddress, // send to ETH token contract
 				EntryPointSelector: selector,
 			}))
 		}
 	}
-	var empty bool
-	for i := 0; i < 30; i++ {
-		time.Sleep(500 * time.Millisecond)
+
+	assert.Eventually(t, func() bool {
 		queued, unconfirmed := txm.InflightCount()
-		accepted := len(observer.FilterMessageSnippet("ACCEPTED_ON_L2").All())
-		t.Logf("inflight count: queued (%d), unconfirmed (%d), accepted (%d)", queued, unconfirmed, accepted)
-
-		// check queue + tx store counts are 0, accepted txs == total txs broadcast
-		if queued == 0 && unconfirmed == 0 {
-			empty = true
-			break
-		}
-	}
-
-	// stop txm
-	assert.True(t, empty, "txm timed out while trying to confirm transactions")
+		return queued == 0 && unconfirmed == 0
+	}, 15*time.Second, 500*time.Millisecond)
 	require.NoError(t, txm.Close())
-	require.Error(t, txm.Ready())
-	assert.Equal(t, 0, observer.FilterLevelExact(zapcore.ErrorLevel).Len())                       // assert no error logs
-	assert.Equal(t, n*len(localKeys), len(observer.FilterMessageSnippet("ACCEPTED_ON_L2").All())) // validate txs were successfully included on chain
+	// Ensure all transactions are confirmed via nonce
+	for accountAddress, initialNonce := range accountAddresses {
+		c, err := getClient()
+		require.NoError(t, err)
+		latestNonce, err := c.AccountNonceLatest(ctx, accountAddress)
+		require.NoError(t, err)
+		require.Equal(t, int(0), new(felt.Felt).Add(initialNonce, new(felt.Felt).SetUint64(nTransactions)).Cmp(latestNonce))
+	}
 }
 
 // LooppKeystore implements [loop.Keystore] interface and the requirements

--- a/relayer/pkg/chainlink/txm/txm_test.go
+++ b/relayer/pkg/chainlink/txm/txm_test.go
@@ -115,7 +115,7 @@ func TestIntegration_Txm(t *testing.T) {
 		t.Logf("inflight count: queued (%d), unconfirmed (%d), accepted (%d)", queued, unconfirmed, accepted)
 
 		// check queue + tx store counts are 0, accepted txs == total txs broadcast
-		if queued == 0 && unconfirmed == 0 && n*len(localKeys) == accepted {
+		if queued == 0 && unconfirmed == 0 {
 			empty = true
 			break
 		}

--- a/relayer/pkg/chainlink/txm/txstore.go
+++ b/relayer/pkg/chainlink/txm/txstore.go
@@ -79,7 +79,7 @@ func (s *TxStore) AddUnconfirmed(nonce *felt.Felt, hash string, call starknetrpc
 
 	nonceStr := nonce.String()
 	if h, exists := s.unconfirmedNonces[nonceStr]; exists {
-		s.lggr.Warnf("nonce used: replacing tx (%s) with nonce (%s) for tx with hash (%s)", h, nonce, hash)
+		s.lggr.Warnf("nonce used: replacing tx (hash: %s) with nonce (%s) for tx with hash (%s)", h.Hash, nonce, hash)
 	}
 
 	s.unconfirmedNonces[nonceStr] = &UnconfirmedTx{
@@ -93,24 +93,24 @@ func (s *TxStore) AddUnconfirmed(nonce *felt.Felt, hash string, call starknetrpc
 	return nil
 }
 
-func (s *TxStore) Confirm(latestNonce *felt.Felt) *string {
+func (s *TxStore) Confirm(latestNonce *felt.Felt) (int, *felt.Felt) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
 	// confirm all transactions with a nonce lower than the latest nonce
+	confirmed := 0
+	highestUnconfirmed := new(felt.Felt).SetUint64(0)
 	for nonceStr, tx := range s.unconfirmedNonces {
 		if tx.Nonce.Cmp(latestNonce) < 0 {
+			confirmed++
 			delete(s.unconfirmedNonces, nonceStr)
+		}
+		if highestUnconfirmed.Cmp(tx.Nonce) < 0 {
+			highestUnconfirmed = tx.Nonce
 		}
 	}
 
-	// if it exists, fetch transaction with the nonce that is expected to be mined next
-	nonceStr := latestNonce.String()
-	unconfirmed, exists := s.unconfirmedNonces[nonceStr]
-	if exists {
-		return &unconfirmed.Hash
-	}
-	return nil
+	return confirmed, highestUnconfirmed
 }
 
 func (s *TxStore) GetUnconfirmed() []*UnconfirmedTx {

--- a/relayer/pkg/chainlink/txm/txstore.go
+++ b/relayer/pkg/chainlink/txm/txstore.go
@@ -8,6 +8,8 @@ import (
 	"github.com/NethermindEth/juno/core/felt"
 	starknetrpc "github.com/NethermindEth/starknet.go/rpc"
 	"golang.org/x/exp/maps"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 )
 
 type UnconfirmedTx struct {
@@ -20,15 +22,17 @@ type UnconfirmedTx struct {
 // TxStore tracks broadcast & unconfirmed txs per account address per chain id
 type TxStore struct {
 	lock sync.RWMutex
+	lggr logger.Logger
 
 	nextNonce         *felt.Felt
 	unconfirmedNonces map[string]*UnconfirmedTx
 }
 
-func NewTxStore(initialNonce *felt.Felt) *TxStore {
+func NewTxStore(initialNonce *felt.Felt, lggr logger.Logger) *TxStore {
 	return &TxStore{
 		nextNonce:         new(felt.Felt).Set(initialNonce),
 		unconfirmedNonces: map[string]*UnconfirmedTx{},
+		lggr:              lggr,
 	}
 }
 
@@ -75,7 +79,7 @@ func (s *TxStore) AddUnconfirmed(nonce *felt.Felt, hash string, call starknetrpc
 
 	nonceStr := nonce.String()
 	if h, exists := s.unconfirmedNonces[nonceStr]; exists {
-		return fmt.Errorf("nonce used: tried to use nonce (%s) for tx (%s), already used by (%s)", nonce, h.Hash, h)
+		s.lggr.Warnf("nonce used: replacing tx (%s) with nonce (%s) for tx with hash (%s)", h, nonce, hash)
 	}
 
 	s.unconfirmedNonces[nonceStr] = &UnconfirmedTx{
@@ -89,20 +93,23 @@ func (s *TxStore) AddUnconfirmed(nonce *felt.Felt, hash string, call starknetrpc
 	return nil
 }
 
-func (s *TxStore) Confirm(nonce *felt.Felt, hash string) error {
+func (s *TxStore) Confirm(latestNonce *felt.Felt) *string {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 
-	nonceStr := nonce.String()
+	// confirm all transactions with a nonce lower than the latest nonce
+	for nonceStr, tx := range s.unconfirmedNonces {
+		if tx.Nonce.Cmp(latestNonce) < 0 {
+			delete(s.unconfirmedNonces, nonceStr)
+		}
+	}
+
+	// if it exists, fetch transaction with the nonce that is expected to be mined next
+	nonceStr := latestNonce.String()
 	unconfirmed, exists := s.unconfirmedNonces[nonceStr]
-	if !exists {
-		return fmt.Errorf("no such unconfirmed nonce: %s", nonce)
+	if exists {
+		return &unconfirmed.Hash
 	}
-	// sanity check that the hash matches
-	if unconfirmed.Hash != hash {
-		return fmt.Errorf("unexpected tx hash: expected %s, got %s", unconfirmed.Hash, hash)
-	}
-	delete(s.unconfirmedNonces, nonceStr)
 	return nil
 }
 
@@ -137,7 +144,14 @@ func NewAccountStore() *AccountStore {
 	}
 }
 
-func (c *AccountStore) CreateTxStore(accountAddress *felt.Felt, initialNonce *felt.Felt) (*TxStore, error) {
+func (c *AccountStore) Accounts() []string {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	return maps.Keys(c.store)
+}
+
+func (c *AccountStore) CreateTxStore(accountAddress *felt.Felt, initialNonce *felt.Felt, lggr logger.Logger) (*TxStore, error) {
 	c.lock.Lock()
 	defer c.lock.Unlock()
 	addressStr := accountAddress.String()
@@ -145,7 +159,7 @@ func (c *AccountStore) CreateTxStore(accountAddress *felt.Felt, initialNonce *fe
 	if ok {
 		return nil, fmt.Errorf("TxStore already exists: %s", accountAddress)
 	}
-	store := NewTxStore(initialNonce)
+	store := NewTxStore(initialNonce, logger.Named(lggr, "TxStore"))
 	c.store[addressStr] = store
 	return store, nil
 }

--- a/relayer/pkg/chainlink/txm/txstore_test.go
+++ b/relayer/pkg/chainlink/txm/txstore_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/NethermindEth/juno/core/felt"
 	starknetrpc "github.com/NethermindEth/starknet.go/rpc"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -26,14 +27,15 @@ func TestTxStore(t *testing.T) {
 		nonce := new(felt.Felt).SetUint64(3)
 		publicKey := new(felt.Felt).SetUint64(7)
 
-		s := NewTxStore(nonce)
+		s := NewTxStore(nonce, logger.Test(t))
 		assert.True(t, s.GetNextNonce().Cmp(nonce) == 0)
 		assert.Equal(t, 0, s.InflightCount())
 		require.NoError(t, s.AddUnconfirmed(nonce, "0x42", call, publicKey))
 		assert.Equal(t, 1, s.InflightCount())
 		assert.Equal(t, 1, len(s.GetUnconfirmed()))
 		assert.Equal(t, "0x42", s.GetUnconfirmed()[0].Hash)
-		require.NoError(t, s.Confirm(nonce, "0x42"))
+		latestNonce := s.GetNextNonce().Add(nonce, new(felt.Felt).SetUint64(1))
+		s.Confirm(latestNonce)
 		assert.Equal(t, 0, s.InflightCount())
 		assert.Equal(t, 0, len(s.GetUnconfirmed()))
 		assert.True(t, s.GetNextNonce().Cmp(new(felt.Felt).Add(nonce, new(felt.Felt).SetUint64(1))) == 0)
@@ -43,7 +45,7 @@ func TestTxStore(t *testing.T) {
 		t.Parallel()
 
 		// create
-		s := NewTxStore(new(felt.Felt).SetUint64(0))
+		s := NewTxStore(new(felt.Felt).SetUint64(0), logger.Test(t))
 
 		call := starknetrpc.FunctionCall{
 			ContractAddress:    new(felt.Felt).SetUint64(0),
@@ -104,42 +106,38 @@ func TestTxStore(t *testing.T) {
 		publicKey := new(felt.Felt).SetUint64(7)
 
 		// init store
-		s := NewTxStore(new(felt.Felt).SetUint64(0))
+		s := NewTxStore(new(felt.Felt).SetUint64(0), logger.Test(t))
 		for i := uint64(0); i < 6; i++ {
 			require.NoError(t, s.AddUnconfirmed(new(felt.Felt).SetUint64(i), "0x"+fmt.Sprintf("%d", i), call, publicKey))
 		}
 
 		// confirm in order
-		require.NoError(t, s.Confirm(new(felt.Felt).SetUint64(0), "0x0"))
-		require.NoError(t, s.Confirm(new(felt.Felt).SetUint64(1), "0x1"))
+		s.Confirm(new(felt.Felt).SetUint64(1))
+		s.Confirm(new(felt.Felt).SetUint64(2))
 		assert.Equal(t, 4, s.InflightCount())
 
 		// confirm out of order
-		require.NoError(t, s.Confirm(new(felt.Felt).SetUint64(4), "0x4"))
-		require.NoError(t, s.Confirm(new(felt.Felt).SetUint64(3), "0x3"))
-		require.NoError(t, s.Confirm(new(felt.Felt).SetUint64(2), "0x2"))
+		s.Confirm(new(felt.Felt).SetUint64(5))
+		s.Confirm(new(felt.Felt).SetUint64(4))
+		s.Confirm(new(felt.Felt).SetUint64(3))
 		assert.Equal(t, 1, s.InflightCount())
 
-		// confirm unknown/duplicate
-		require.ErrorContains(t, s.Confirm(new(felt.Felt).SetUint64(10), "0x10"), "no such unconfirmed nonce")
-		// confirm with incorrect hash
-		require.ErrorContains(t, s.Confirm(new(felt.Felt).SetUint64(5), "0x99"), "unexpected tx hash")
+		// confirm all previous txs
+		s.Confirm(new(felt.Felt).SetUint64(10))
+		assert.Equal(t, 0, s.InflightCount())
 
 		// race confirm
-		var err0 error
-		var err1 error
 		var wg sync.WaitGroup
 		wg.Add(2)
 		go func() {
-			err0 = s.Confirm(new(felt.Felt).SetUint64(5), "0x5")
+			s.Confirm(new(felt.Felt).SetUint64(5))
 			wg.Done()
 		}()
 		go func() {
-			err1 = s.Confirm(new(felt.Felt).SetUint64(5), "0x5")
+			s.Confirm(new(felt.Felt).SetUint64(5))
 			wg.Done()
 		}()
 		wg.Wait()
-		assert.True(t, !errors.Is(err0, err1) && ((err0 != nil && err1 == nil) || (err0 == nil && err1 != nil)))
 		assert.Equal(t, 0, s.InflightCount())
 	})
 
@@ -155,7 +153,7 @@ func TestTxStore(t *testing.T) {
 		txCount := uint64(6)
 
 		// init store
-		s := NewTxStore(new(felt.Felt).SetUint64(0))
+		s := NewTxStore(new(felt.Felt).SetUint64(0), logger.Test(t))
 		for i := uint64(0); i < txCount; i++ {
 			require.NoError(t, s.AddUnconfirmed(new(felt.Felt).SetUint64(i), "0x"+fmt.Sprintf("%d", i), call, publicKey))
 		}
@@ -192,13 +190,13 @@ func TestAccountStore(t *testing.T) {
 	felt0 := new(felt.Felt).SetUint64(0)
 	felt1 := new(felt.Felt).SetUint64(1)
 
-	store0, err := c.CreateTxStore(felt0, felt0)
+	store0, err := c.CreateTxStore(felt0, felt0, logger.Test(t))
 	require.NoError(t, err)
 
-	store1, err := c.CreateTxStore(felt1, felt1)
+	store1, err := c.CreateTxStore(felt1, felt1, logger.Test(t))
 	require.NoError(t, err)
 
-	_, err = c.CreateTxStore(felt0, felt0)
+	_, err = c.CreateTxStore(felt0, felt0, logger.Test(t))
 	require.ErrorContains(t, err, "TxStore already exists")
 
 	assert.Equal(t, store0, c.GetTxStore(felt0))

--- a/relayer/pkg/starknet/client.go
+++ b/relayer/pkg/starknet/client.go
@@ -173,3 +173,13 @@ func (c *Client) AccountNonce(ctx context.Context, accountAddress *felt.Felt) (*
 
 	return c.Provider.Nonce(ctx, starknetrpc.BlockID{Tag: "pending"}, accountAddress)
 }
+
+func (c *Client) AccountNonceLatest(ctx context.Context, accountAddress *felt.Felt) (*felt.Felt, error) {
+	if c.defaultTimeout != 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, c.defaultTimeout)
+		defer cancel()
+	}
+
+	return c.Provider.Nonce(ctx, starknetrpc.BlockID{Tag: "latest"}, accountAddress)
+}


### PR DESCRIPTION
### RPC nonce error check
The code fixes how the TXM checks for a nonce error from the RPC by comparing the error message. The old check included an additional object that attempted to deserialize the error, but it resulted in nil, which effectively rendered the check useless.  

### Updated transaction confirmation logic
Transactions are no longer confirmed individually per transaction hash; instead, it uses the latest nonce to confirm transactions with a nonce lower than that (similar to EVM TXMv2). This was done for two reasons. First, the RPC responses are slow and unreliable for transaction status. Second, the old confirmation logic doesn't cover the case where a transaction is no longer tracked (either because the RPC evicted the transaction from mempool or failed internally during broadcast, but returned success).

### Added transaction throttling
Unfortunately, not all RPCs will return an error when broadcasting a transaction with a nonce higher than the pending, and will keep the transaction in the mempool up to a large threshold, similar to EVM. That means, if there is a nonce gap, the TXM will be very slow to detect and resync. This is very crucial, especially after a nonce gap is created and there aren't many transactions in the queue. To fix this, the confirmation loop adds a transaction throttling mechanism for in-flight transactions via a constant value. If that threshold is exceeded, the TXM will do a resync of the local nonce. This doesn't necessarily mean that previous transactions will be overwritten, since the broadcasting loop has its own nonce fast-forwarding mechanism. You can think of this throttling mechanism as a "chance" for the broadcast loop and the TXM to go back and replay the nonce and find gaps. That doesn't mean transactions won't be overwritten, but that's a property the original TXM didn't support anyway.

### Transaction overwrite
A major issue with the old design was that the TXM assumed that a successful message during broadcast means the transaction will always be either on the mempool or mined, which, as explained above, it's not the case. This has led to nonce gap incidents. To protect against that, and enable the `nonceResync` mechanism, we allow the TxStore to overwrite unconfirmed transactions with the same nonce if the nonce resyncs. On some edge cases, it means that a past transaction was replaced by a more recent one, which is already expected by the TXM, but in the majority, this means an untracked transaction was dropped for a new one that will fill the nonce gap.