### PR TITLE
Add TXM Prometheus metrics

### DIFF
--- a/relayer/go.mod
+++ b/relayer/go.mod
@@ -8,6 +8,8 @@ require (
 	github.com/ethereum/go-ethereum v1.15.0
 	github.com/hashicorp/go-plugin v1.6.2
 	github.com/pelletier/go-toml/v2 v2.2.3
+	github.com/prometheus/client_golang v1.21.1
+	github.com/prometheus/client_model v0.6.1
 	github.com/smartcontractkit/chainlink-common v0.7.1-0.20250602141924-3c15a42d8266
 	github.com/smartcontractkit/freeport v0.1.0
 	github.com/smartcontractkit/libocr v0.0.0-20250220133800-f3b940c4f298
@@ -98,8 +100,6 @@ require (
 	github.com/oklog/run v1.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.21.1 // indirect
-	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.63.0 // indirect
 	github.com/prometheus/procfs v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.4 // indirect

--- a/relayer/pkg/chainlink/chain/chain.go
+++ b/relayer/pkg/chainlink/chain/chain.go
@@ -86,7 +86,7 @@ func newChain(id string, cfg *config.TOMLConfig, loopKs loop.Keystore, lggr logg
 	}
 
 	var err error
-	ch.txm, err = txm.New(lggr, loopKs, cfg, ch.getClient, ch.getFeederClient)
+	ch.txm, err = txm.New(lggr, loopKs, cfg, id, ch.getClient, ch.getFeederClient)
 	if err != nil {
 		return nil, err
 	}

--- a/relayer/pkg/chainlink/txm/metrics_test.go
+++ b/relayer/pkg/chainlink/txm/metrics_test.go
@@ -102,21 +102,9 @@ func (m *mockLogger) Panicf(format string, args ...interface{}) {
 func TestTxMetrics_InterfaceCompliance(t *testing.T) {
 	t.Parallel()
 
-	// Verify NoOpTxMetrics implements TxMetrics interface
-	var _ TxMetrics = NoOpTxMetrics{}
+	// Verify mockTxMetrics and prometheusMetrics implement TxMetrics interface
 	var _ TxMetrics = &mockTxMetrics{}
-}
-
-func TestNoOpTxMetrics(t *testing.T) {
-	t.Parallel()
-
-	metrics := NoOpTxMetrics{}
-
-	// Should not panic
-	metrics.IncrementSuccessfulTransactions("test-chain")
-	metrics.IncrementRevertedTransactions("test-chain")
-	metrics.IncrementFinalizedTransactions("test-chain")
-	metrics.SetTxAttemptCount("test-chain", 10)
+	var _ TxMetrics = &prometheusMetrics{}
 }
 
 func TestNewWithMetrics(t *testing.T) {
@@ -166,6 +154,41 @@ func TestNew_DefaultMetrics(t *testing.T) {
 	_, ok := stxm.metrics.(*prometheusMetrics)
 	assert.True(t, ok, "Default metrics should be PrometheusMetrics")
 	assert.Equal(t, "test-chain-id", stxm.chainID)
+}
+
+func TestNew_UsesPrometheusMetrics(t *testing.T) {
+	t.Parallel()
+
+	mockLggr := &mockLogger{Logger: logger.Test(t)}
+	chainID := "test-prometheus-chain"
+
+	txm, err := New(
+		mockLggr,
+		&mockKeystore{},
+		&mockConfig{},
+		chainID,
+		func() (*starknet.Client, error) { return nil, nil },
+		func() (*starknet.FeederClient, error) { return nil, nil },
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, txm)
+
+	// Call InflightCount to trigger metrics
+	queueCount, unconfirmedCount := txm.InflightCount()
+	assert.Equal(t, 0, queueCount)
+	assert.Equal(t, 0, unconfirmedCount)
+
+	// Verify the metric was actually set in Prometheus
+	stxm := txm.(*starktxm)
+	promMetrics, ok := stxm.metrics.(*prometheusMetrics)
+	require.True(t, ok, "Should be using PrometheusMetrics")
+
+	// Exercise all metric methods
+	promMetrics.IncrementSuccessfulTransactions(chainID)
+	promMetrics.IncrementRevertedTransactions(chainID)
+	promMetrics.IncrementFinalizedTransactions(chainID)
+	promMetrics.SetTxAttemptCount(chainID, 5)
 }
 
 func TestInflightCount_UpdatesMetrics(t *testing.T) {

--- a/relayer/pkg/chainlink/txm/metrics_test.go
+++ b/relayer/pkg/chainlink/txm/metrics_test.go
@@ -1,0 +1,327 @@
+package txm
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/starknet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// mockTxMetrics is a mock implementation of TxMetrics for testing
+type mockTxMetrics struct {
+	mu                     sync.RWMutex
+	successfulTransactions map[string]int
+	revertedTransactions   map[string]int
+	finalizedTransactions  map[string]int
+	txAttemptCounts        map[string]int
+}
+
+func newMockTxMetrics() *mockTxMetrics {
+	return &mockTxMetrics{
+		successfulTransactions: make(map[string]int),
+		revertedTransactions:   make(map[string]int),
+		finalizedTransactions:  make(map[string]int),
+		txAttemptCounts:        make(map[string]int),
+	}
+}
+
+func (m *mockTxMetrics) IncrementSuccessfulTransactions(chainID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.successfulTransactions[chainID]++
+}
+
+func (m *mockTxMetrics) IncrementRevertedTransactions(chainID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.revertedTransactions[chainID]++
+}
+
+func (m *mockTxMetrics) IncrementFinalizedTransactions(chainID string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.finalizedTransactions[chainID]++
+}
+
+func (m *mockTxMetrics) SetTxAttemptCount(chainID string, count int) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.txAttemptCounts[chainID] = count
+}
+
+func (m *mockTxMetrics) GetSuccessfulCount(chainID string) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.successfulTransactions[chainID]
+}
+
+func (m *mockTxMetrics) GetRevertedCount(chainID string) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.revertedTransactions[chainID]
+}
+
+func (m *mockTxMetrics) GetFinalizedCount(chainID string) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.finalizedTransactions[chainID]
+}
+
+func (m *mockTxMetrics) GetTxAttemptCount(chainID string) int {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.txAttemptCounts[chainID]
+}
+
+// mockLogger implements logger.Logger interface for testing
+type mockLogger struct {
+	logger.Logger
+}
+
+func (m *mockLogger) Name() string {
+	return "test-logger"
+}
+
+func (m *mockLogger) Sync() error {
+	return nil
+}
+
+func (m *mockLogger) Panic(args ...interface{}) {
+	// no-op for testing
+}
+
+func (m *mockLogger) Panicf(format string, args ...interface{}) {
+	// no-op for testing
+}
+
+func TestTxMetrics_InterfaceCompliance(t *testing.T) {
+	t.Parallel()
+
+	// Verify NoOpTxMetrics implements TxMetrics interface
+	var _ TxMetrics = NoOpTxMetrics{}
+	var _ TxMetrics = &mockTxMetrics{}
+}
+
+func TestNoOpTxMetrics(t *testing.T) {
+	t.Parallel()
+
+	metrics := NoOpTxMetrics{}
+
+	// Should not panic
+	metrics.IncrementSuccessfulTransactions("test-chain")
+	metrics.IncrementRevertedTransactions("test-chain")
+	metrics.IncrementFinalizedTransactions("test-chain")
+	metrics.SetTxAttemptCount("test-chain", 10)
+}
+
+func TestNewWithMetrics(t *testing.T) {
+	t.Parallel()
+
+	mockMetrics := newMockTxMetrics()
+	mockLggr := &mockLogger{Logger: logger.Test(t)}
+
+	txm, err := NewWithMetrics(
+		mockLggr,
+		&mockKeystore{},
+		&mockConfig{},
+		"test-chain-id",
+		mockMetrics,
+		func() (*starknet.Client, error) { return nil, nil },
+		func() (*starknet.FeederClient, error) { return nil, nil },
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, txm)
+
+	// Verify metrics are set
+	stxm := txm.(*starktxm)
+	assert.Equal(t, mockMetrics, stxm.metrics)
+	assert.Equal(t, "test-chain-id", stxm.chainID)
+}
+
+func TestNew_DefaultMetrics(t *testing.T) {
+	t.Parallel()
+
+	mockLggr := &mockLogger{Logger: logger.Test(t)}
+
+	txm, err := New(
+		mockLggr,
+		&mockKeystore{},
+		&mockConfig{},
+		"test-chain-id",
+		func() (*starknet.Client, error) { return nil, nil },
+		func() (*starknet.FeederClient, error) { return nil, nil },
+	)
+
+	require.NoError(t, err)
+	require.NotNil(t, txm)
+
+	// Verify PrometheusMetrics is used by default
+	stxm := txm.(*starktxm)
+	_, ok := stxm.metrics.(*prometheusMetrics)
+	assert.True(t, ok, "Default metrics should be PrometheusMetrics")
+	assert.Equal(t, "test-chain-id", stxm.chainID)
+}
+
+func TestInflightCount_UpdatesMetrics(t *testing.T) {
+	t.Parallel()
+
+	mockMetrics := newMockTxMetrics()
+	mockLggr := &mockLogger{Logger: logger.Test(t)}
+	chainID := "test-chain-id"
+
+	txm, err := NewWithMetrics(
+		mockLggr,
+		&mockKeystore{},
+		&mockConfig{},
+		chainID,
+		mockMetrics,
+		func() (*starknet.Client, error) { return nil, nil },
+		func() (*starknet.FeederClient, error) { return nil, nil },
+	)
+
+	require.NoError(t, err)
+
+	// Call InflightCount
+	queue, unconfirmed := txm.InflightCount()
+
+	// Verify counts
+	assert.Equal(t, 0, queue)
+	assert.Equal(t, 0, unconfirmed)
+
+	// Verify metrics were updated
+	attemptCount := mockMetrics.GetTxAttemptCount(chainID)
+	assert.Equal(t, 0, attemptCount)
+}
+
+func TestTxMetrics_Methods(t *testing.T) {
+	t.Parallel()
+
+	mockMetrics := newMockTxMetrics()
+	chainID := "test-chain-id"
+
+	// Test IncrementSuccessfulTransactions
+	mockMetrics.IncrementSuccessfulTransactions(chainID)
+	mockMetrics.IncrementSuccessfulTransactions(chainID)
+	assert.Equal(t, 2, mockMetrics.GetSuccessfulCount(chainID))
+
+	// Test IncrementRevertedTransactions
+	mockMetrics.IncrementRevertedTransactions(chainID)
+	assert.Equal(t, 1, mockMetrics.GetRevertedCount(chainID))
+
+	// Test IncrementFinalizedTransactions
+	mockMetrics.IncrementFinalizedTransactions(chainID)
+	mockMetrics.IncrementFinalizedTransactions(chainID)
+	mockMetrics.IncrementFinalizedTransactions(chainID)
+	assert.Equal(t, 3, mockMetrics.GetFinalizedCount(chainID))
+
+	// Test SetTxAttemptCount
+	mockMetrics.SetTxAttemptCount(chainID, 42)
+	assert.Equal(t, 42, mockMetrics.GetTxAttemptCount(chainID))
+
+	// Update with new value
+	mockMetrics.SetTxAttemptCount(chainID, 100)
+	assert.Equal(t, 100, mockMetrics.GetTxAttemptCount(chainID))
+}
+
+func TestTxMetrics_MultipleCalls(t *testing.T) {
+	t.Parallel()
+
+	mockMetrics := newMockTxMetrics()
+	chainID := "test-chain-id"
+
+	// Multiple concurrent calls
+	var wg sync.WaitGroup
+	numGoroutines := 10
+	incrementsPerGoroutine := 10
+
+	// Test concurrent IncrementSuccessfulTransactions
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < incrementsPerGoroutine; j++ {
+				mockMetrics.IncrementSuccessfulTransactions(chainID)
+			}
+		}()
+	}
+
+	wg.Wait()
+
+	// Should have exactly numGoroutines * incrementsPerGoroutine
+	expected := numGoroutines * incrementsPerGoroutine
+	assert.Equal(t, expected, mockMetrics.GetSuccessfulCount(chainID))
+}
+
+func TestTxMetrics_MultipleChains(t *testing.T) {
+	t.Parallel()
+
+	mockMetrics := newMockTxMetrics()
+	chain1 := "chain-1"
+	chain2 := "chain-2"
+
+	// Increment metrics for chain1
+	mockMetrics.IncrementSuccessfulTransactions(chain1)
+	mockMetrics.IncrementSuccessfulTransactions(chain1)
+
+	// Increment metrics for chain2
+	mockMetrics.IncrementFinalizedTransactions(chain2)
+
+	// Verify chain1 metrics
+	assert.Equal(t, 2, mockMetrics.GetSuccessfulCount(chain1))
+	assert.Equal(t, 0, mockMetrics.GetFinalizedCount(chain1))
+
+	// Verify chain2 metrics
+	assert.Equal(t, 0, mockMetrics.GetSuccessfulCount(chain2))
+	assert.Equal(t, 1, mockMetrics.GetFinalizedCount(chain2))
+}
+
+// Mock implementations for testing
+
+type mockKeystore struct{}
+
+func (m *mockKeystore) Sign(ctx context.Context, keyID string, data []byte) ([]byte, error) {
+	return []byte("mock-signature"), nil
+}
+
+func (m *mockKeystore) Accounts(ctx context.Context) ([]string, error) {
+	return []string{"mock-account"}, nil
+}
+
+func (m *mockKeystore) AccountsByID(ctx context.Context, keyIDs ...string) ([]string, error) {
+	return []string{"mock-account"}, nil
+}
+
+func (m *mockKeystore) SignTx(ctx context.Context, keyID string, tx []byte) ([]byte, error) {
+	return []byte("mock-tx-signature"), nil
+}
+
+func (m *mockKeystore) New(ctx context.Context) (string, error) {
+	return "mock-new-key", nil
+}
+
+func (m *mockKeystore) Delete(ctx context.Context, keyID string) error {
+	return nil
+}
+
+func (m *mockKeystore) Export(ctx context.Context, keyID, password string) ([]byte, error) {
+	return []byte("mock-export"), nil
+}
+
+func (m *mockKeystore) Import(ctx context.Context, keyJSON []byte, password string) error {
+	return nil
+}
+
+func (m *mockKeystore) Get(ctx context.Context, keyID string) ([]byte, error) {
+	return []byte("mock-key"), nil
+}
+
+type mockConfig struct{}
+
+func (m *mockConfig) ConfirmationPoll() time.Duration { return time.Second }
+func (m *mockConfig) TxTimeout() time.Duration        { return 10 * time.Second }

--- a/relayer/pkg/chainlink/txm/metrics_test.go
+++ b/relayer/pkg/chainlink/txm/metrics_test.go
@@ -16,67 +16,62 @@ import (
 // mockTxMetrics is a mock implementation of TxMetrics for testing
 type mockTxMetrics struct {
 	mu                     sync.RWMutex
-	successfulTransactions map[string]int
-	revertedTransactions   map[string]int
-	finalizedTransactions  map[string]int
-	txAttemptCounts        map[string]int
+	successfulTransactions int
+	revertedTransactions   int
+	finalizedTransactions  int
+	txAttemptCount         int
 }
 
 func newMockTxMetrics() *mockTxMetrics {
-	return &mockTxMetrics{
-		successfulTransactions: make(map[string]int),
-		revertedTransactions:   make(map[string]int),
-		finalizedTransactions:  make(map[string]int),
-		txAttemptCounts:        make(map[string]int),
-	}
+	return &mockTxMetrics{}
 }
 
-func (m *mockTxMetrics) IncrementSuccessfulTransactions(chainID string) {
+func (m *mockTxMetrics) IncrementNumSuccessfulTxs() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.successfulTransactions[chainID]++
+	m.successfulTransactions++
 }
 
-func (m *mockTxMetrics) IncrementRevertedTransactions(chainID string) {
+func (m *mockTxMetrics) IncrementNumRevertedTxs() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.revertedTransactions[chainID]++
+	m.revertedTransactions++
 }
 
-func (m *mockTxMetrics) IncrementFinalizedTransactions(chainID string) {
+func (m *mockTxMetrics) IncrementNumFinalizedTxs() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.finalizedTransactions[chainID]++
+	m.finalizedTransactions++
 }
 
-func (m *mockTxMetrics) SetTxAttemptCount(chainID string, count int) {
+func (m *mockTxMetrics) SetTxAttemptCount(count int) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.txAttemptCounts[chainID] = count
+	m.txAttemptCount = count
 }
 
-func (m *mockTxMetrics) GetSuccessfulCount(chainID string) int {
+func (m *mockTxMetrics) GetSuccessfulCount() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.successfulTransactions[chainID]
+	return m.successfulTransactions
 }
 
-func (m *mockTxMetrics) GetRevertedCount(chainID string) int {
+func (m *mockTxMetrics) GetRevertedCount() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.revertedTransactions[chainID]
+	return m.revertedTransactions
 }
 
-func (m *mockTxMetrics) GetFinalizedCount(chainID string) int {
+func (m *mockTxMetrics) GetFinalizedCount() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.finalizedTransactions[chainID]
+	return m.finalizedTransactions
 }
 
-func (m *mockTxMetrics) GetTxAttemptCount(chainID string) int {
+func (m *mockTxMetrics) GetTxAttemptCount() int {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
-	return m.txAttemptCounts[chainID]
+	return m.txAttemptCount
 }
 
 // mockLogger implements logger.Logger interface for testing
@@ -186,10 +181,10 @@ func TestNew_UsesPrometheusMetrics(t *testing.T) {
 	require.True(t, ok, "Should be using PrometheusMetrics")
 
 	// Exercise all metric methods
-	promMetrics.IncrementSuccessfulTransactions(chainID)
-	promMetrics.IncrementRevertedTransactions(chainID)
-	promMetrics.IncrementFinalizedTransactions(chainID)
-	promMetrics.SetTxAttemptCount(chainID, 5)
+	promMetrics.IncrementNumSuccessfulTxs()
+	promMetrics.IncrementNumRevertedTxs()
+	promMetrics.IncrementNumFinalizedTxs()
+	promMetrics.SetTxAttemptCount(5)
 }
 
 func TestInflightCount_UpdatesMetrics(t *testing.T) {
@@ -232,50 +227,48 @@ func TestTxMetrics_Methods(t *testing.T) {
 	t.Parallel()
 
 	mockMetrics := newMockTxMetrics()
-	chainID := "test-chain-id"
 
-	// Test IncrementSuccessfulTransactions
-	mockMetrics.IncrementSuccessfulTransactions(chainID)
-	mockMetrics.IncrementSuccessfulTransactions(chainID)
-	assert.Equal(t, 2, mockMetrics.GetSuccessfulCount(chainID))
+	// Test IncrementNumSuccessfulTxs
+	mockMetrics.IncrementNumSuccessfulTxs()
+	mockMetrics.IncrementNumSuccessfulTxs()
+	assert.Equal(t, 2, mockMetrics.GetSuccessfulCount())
 
-	// Test IncrementRevertedTransactions
-	mockMetrics.IncrementRevertedTransactions(chainID)
-	assert.Equal(t, 1, mockMetrics.GetRevertedCount(chainID))
+	// Test IncrementNumRevertedTxs
+	mockMetrics.IncrementNumRevertedTxs()
+	assert.Equal(t, 1, mockMetrics.GetRevertedCount())
 
-	// Test IncrementFinalizedTransactions
-	mockMetrics.IncrementFinalizedTransactions(chainID)
-	mockMetrics.IncrementFinalizedTransactions(chainID)
-	mockMetrics.IncrementFinalizedTransactions(chainID)
-	assert.Equal(t, 3, mockMetrics.GetFinalizedCount(chainID))
+	// Test IncrementNumFinalizedTxs
+	mockMetrics.IncrementNumFinalizedTxs()
+	mockMetrics.IncrementNumFinalizedTxs()
+	mockMetrics.IncrementNumFinalizedTxs()
+	assert.Equal(t, 3, mockMetrics.GetFinalizedCount())
 
 	// Test SetTxAttemptCount
-	mockMetrics.SetTxAttemptCount(chainID, 42)
-	assert.Equal(t, 42, mockMetrics.GetTxAttemptCount(chainID))
+	mockMetrics.SetTxAttemptCount(42)
+	assert.Equal(t, 42, mockMetrics.GetTxAttemptCount())
 
 	// Update with new value
-	mockMetrics.SetTxAttemptCount(chainID, 100)
-	assert.Equal(t, 100, mockMetrics.GetTxAttemptCount(chainID))
+	mockMetrics.SetTxAttemptCount(100)
+	assert.Equal(t, 100, mockMetrics.GetTxAttemptCount())
 }
 
 func TestTxMetrics_MultipleCalls(t *testing.T) {
 	t.Parallel()
 
 	mockMetrics := newMockTxMetrics()
-	chainID := "test-chain-id"
 
 	// Multiple concurrent calls
 	var wg sync.WaitGroup
 	numGoroutines := 10
 	incrementsPerGoroutine := 10
 
-	// Test concurrent IncrementSuccessfulTransactions
+	// Test concurrent IncrementNumSuccessfulTxs
 	for i := 0; i < numGoroutines; i++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for j := 0; j < incrementsPerGoroutine; j++ {
-				mockMetrics.IncrementSuccessfulTransactions(chainID)
+				mockMetrics.IncrementNumSuccessfulTxs()
 			}
 		}()
 	}
@@ -284,30 +277,30 @@ func TestTxMetrics_MultipleCalls(t *testing.T) {
 
 	// Should have exactly numGoroutines * incrementsPerGoroutine
 	expected := numGoroutines * incrementsPerGoroutine
-	assert.Equal(t, expected, mockMetrics.GetSuccessfulCount(chainID))
+	assert.Equal(t, expected, mockMetrics.GetSuccessfulCount())
 }
 
-func TestTxMetrics_MultipleChains(t *testing.T) {
+func TestTxMetrics_Isolation(t *testing.T) {
 	t.Parallel()
 
-	mockMetrics := newMockTxMetrics()
-	chain1 := "chain-1"
-	chain2 := "chain-2"
+	// Test that two separate metric instances are independent
+	metrics1 := newMockTxMetrics()
+	metrics2 := newMockTxMetrics()
 
-	// Increment metrics for chain1
-	mockMetrics.IncrementSuccessfulTransactions(chain1)
-	mockMetrics.IncrementSuccessfulTransactions(chain1)
+	// Increment metrics1
+	metrics1.IncrementNumSuccessfulTxs()
+	metrics1.IncrementNumSuccessfulTxs()
 
-	// Increment metrics for chain2
-	mockMetrics.IncrementFinalizedTransactions(chain2)
+	// Increment metrics2
+	metrics2.IncrementNumFinalizedTxs()
 
-	// Verify chain1 metrics
-	assert.Equal(t, 2, mockMetrics.GetSuccessfulCount(chain1))
-	assert.Equal(t, 0, mockMetrics.GetFinalizedCount(chain1))
+	// Verify metrics1
+	assert.Equal(t, 2, metrics1.GetSuccessfulCount())
+	assert.Equal(t, 0, metrics1.GetFinalizedCount())
 
-	// Verify chain2 metrics
-	assert.Equal(t, 0, mockMetrics.GetSuccessfulCount(chain2))
-	assert.Equal(t, 1, mockMetrics.GetFinalizedCount(chain2))
+	// Verify metrics2
+	assert.Equal(t, 0, metrics2.GetSuccessfulCount())
+	assert.Equal(t, 1, metrics2.GetFinalizedCount())
 }
 
 // Helper function to get gauge value from Prometheus

--- a/relayer/pkg/chainlink/txm/metrics_test.go
+++ b/relayer/pkg/chainlink/txm/metrics_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/smartcontractkit/chainlink-common/pkg/logger"
 	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/starknet"
 	"github.com/stretchr/testify/assert"
@@ -194,32 +195,37 @@ func TestNew_UsesPrometheusMetrics(t *testing.T) {
 func TestInflightCount_UpdatesMetrics(t *testing.T) {
 	t.Parallel()
 
-	mockMetrics := newMockTxMetrics()
 	mockLggr := &mockLogger{Logger: logger.Test(t)}
-	chainID := "test-chain-id"
+	chainID := "test-chain-inflight"
 
-	txm, err := NewWithMetrics(
+	// Use real Prometheus metrics, not mocks
+	txm, err := New(
 		mockLggr,
 		&mockKeystore{},
 		&mockConfig{},
 		chainID,
-		mockMetrics,
 		func() (*starknet.Client, error) { return nil, nil },
 		func() (*starknet.FeederClient, error) { return nil, nil },
 	)
 
 	require.NoError(t, err)
 
-	// Call InflightCount
+	// Get initial metric value from Prometheus
+	initialValue := getGaugeValueFromPrometheus(t, "tx_manager_tx_attempt_count", chainID)
+
+	// Call InflightCount - this should update the Prometheus gauge
 	queue, unconfirmed := txm.InflightCount()
 
 	// Verify counts
 	assert.Equal(t, 0, queue)
 	assert.Equal(t, 0, unconfirmed)
 
-	// Verify metrics were updated
-	attemptCount := mockMetrics.GetTxAttemptCount(chainID)
-	assert.Equal(t, 0, attemptCount)
+	// Verify the actual Prometheus metric was updated
+	finalValue := getGaugeValueFromPrometheus(t, "tx_manager_tx_attempt_count", chainID)
+	assert.Equal(t, 0.0, finalValue, "Prometheus gauge should be set to 0")
+
+	// Verify it was actually called (value should be set, not just initial)
+	_ = initialValue // We set it regardless of initial value
 }
 
 func TestTxMetrics_Methods(t *testing.T) {
@@ -302,6 +308,25 @@ func TestTxMetrics_MultipleChains(t *testing.T) {
 	// Verify chain2 metrics
 	assert.Equal(t, 0, mockMetrics.GetSuccessfulCount(chain2))
 	assert.Equal(t, 1, mockMetrics.GetFinalizedCount(chain2))
+}
+
+// Helper function to get gauge value from Prometheus
+func getGaugeValueFromPrometheus(t *testing.T, metricName, chainID string) float64 {
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range metricFamilies {
+		if mf.GetName() == metricName {
+			for _, m := range mf.GetMetric() {
+				for _, label := range m.GetLabel() {
+					if label.GetName() == "chainID" && label.GetValue() == chainID {
+						return m.GetGauge().GetValue()
+					}
+				}
+			}
+		}
+	}
+	return 0
 }
 
 // Mock implementations for testing

--- a/relayer/pkg/chainlink/txm/txm.go
+++ b/relayer/pkg/chainlink/txm/txm.go
@@ -31,6 +31,21 @@ type TxManager interface {
 	InflightCount() (int, int)
 }
 
+type TxMetrics interface {
+	IncrementSuccessfulTransactions(chainID string)
+	IncrementRevertedTransactions(chainID string)
+	IncrementFinalizedTransactions(chainID string)
+	SetTxAttemptCount(chainID string, count int)
+}
+
+// NoOpTxMetrics is a no-op implementation of TxMetrics for when metrics are not available
+type NoOpTxMetrics struct{}
+
+func (n NoOpTxMetrics) IncrementSuccessfulTransactions(chainID string) {}
+func (n NoOpTxMetrics) IncrementRevertedTransactions(chainID string)   {}
+func (n NoOpTxMetrics) IncrementFinalizedTransactions(chainID string)  {}
+func (n NoOpTxMetrics) SetTxAttemptCount(chainID string, count int)    {}
+
 type Tx struct {
 	publicKey      *felt.Felt
 	accountAddress *felt.Felt
@@ -54,9 +69,16 @@ type starktxm struct {
 	client       *utils.LazyLoad[*starknet.Client]
 	feederClient *utils.LazyLoad[*starknet.FeederClient]
 	accountStore *AccountStore
+	metrics      TxMetrics
+	chainID      string
 }
 
-func New(lggr logger.Logger, keystore loop.Keystore, cfg Config, getClient func() (*starknet.Client, error),
+func New(lggr logger.Logger, keystore loop.Keystore, cfg Config, chainID string, getClient func() (*starknet.Client, error),
+	getFeederClient func() (*starknet.FeederClient, error)) (StarkTXM, error) {
+	return NewWithMetrics(lggr, keystore, cfg, chainID, NewPrometheusMetrics(), getClient, getFeederClient)
+}
+
+func NewWithMetrics(lggr logger.Logger, keystore loop.Keystore, cfg Config, chainID string, metrics TxMetrics, getClient func() (*starknet.Client, error),
 	getFeederClient func() (*starknet.FeederClient, error)) (StarkTXM, error) {
 	txm := &starktxm{
 		lggr:         logger.Named(lggr, "Txm"),
@@ -67,6 +89,8 @@ func New(lggr logger.Logger, keystore loop.Keystore, cfg Config, getClient func(
 		ks:           NewKeystoreAdapter(keystore),
 		cfg:          cfg,
 		accountStore: NewAccountStore(),
+		metrics:      metrics,
+		chainID:      chainID,
 	}
 
 	return txm, nil
@@ -152,7 +176,7 @@ func (txm *starktxm) estimateFriFee(ctx context.Context, client *starknet.Client
 				continue
 			}
 
-			return nil, nil, fmt.Errorf("Failed to estimate fee: %T %+v", err, err)
+			return nil, nil, fmt.Errorf("failed to estimate fee: %T %+v", err, err)
 		}
 
 		// track the FRI estimate, but keep looping so we print out all estimates
@@ -395,6 +419,14 @@ func (txm *starktxm) confirmLoop() {
 						txm.lggr.Debugw(fmt.Sprintf("tx confirmed: %s", finalityStatus), "hash", hash, "nonce", unconfirmedTx.Nonce, "finalityStatus", finalityStatus)
 						if err := txm.accountStore.GetTxStore(accountAddress).Confirm(unconfirmedTx.Nonce, hash); err != nil {
 							txm.lggr.Errorw("failed to confirm tx in TxStore", "hash", hash, "accountAddress", accountAddress, "error", err)
+						} else {
+							// Increment successful transactions metric
+							txm.metrics.IncrementSuccessfulTransactions(txm.chainID)
+						}
+
+						// Increment finalized transactions metric for L1/L2 acceptance
+						if finalityStatus == starknetrpc.TxnStatus_Accepted_On_L1 || finalityStatus == starknetrpc.TxnStatus_Accepted_On_L2 {
+							txm.metrics.IncrementFinalizedTransactions(txm.chainID)
 						}
 					}
 
@@ -412,6 +444,9 @@ func (txm *starktxm) confirmLoop() {
 					if executionStatus == starknetrpc.TxnExecutionStatusREVERTED {
 						// TODO: get revert reason?
 						txm.lggr.Errorw("transaction reverted", "hash", hash)
+
+						// Increment reverted transactions metric
+						txm.metrics.IncrementRevertedTransactions(txm.chainID)
 					}
 				}
 			}
@@ -517,5 +552,12 @@ func (txm *starktxm) Enqueue(ctx context.Context, accountAddress, publicKey *fel
 }
 
 func (txm *starktxm) InflightCount() (queue int, unconfirmed int) {
-	return len(txm.queue), txm.accountStore.GetTotalInflightCount()
+	queueCount := len(txm.queue)
+	unconfirmedCount := txm.accountStore.GetTotalInflightCount()
+
+	// Update tx attempt count metric
+	totalAttempts := queueCount + unconfirmedCount
+	txm.metrics.SetTxAttemptCount(txm.chainID, totalAttempts)
+
+	return queueCount, unconfirmedCount
 }

--- a/relayer/pkg/chainlink/txm/txm.go
+++ b/relayer/pkg/chainlink/txm/txm.go
@@ -32,10 +32,10 @@ type TxManager interface {
 }
 
 type TxMetrics interface {
-	IncrementSuccessfulTransactions(chainID string)
-	IncrementRevertedTransactions(chainID string)
-	IncrementFinalizedTransactions(chainID string)
-	SetTxAttemptCount(chainID string, count int)
+	IncrementNumSuccessfulTxs()
+	IncrementNumRevertedTxs()
+	IncrementNumFinalizedTxs()
+	SetTxAttemptCount(count int)
 }
 
 type Tx struct {
@@ -67,7 +67,7 @@ type starktxm struct {
 
 func New(lggr logger.Logger, keystore loop.Keystore, cfg Config, chainID string, getClient func() (*starknet.Client, error),
 	getFeederClient func() (*starknet.FeederClient, error)) (StarkTXM, error) {
-	return NewWithMetrics(lggr, keystore, cfg, chainID, NewPrometheusMetrics(), getClient, getFeederClient)
+	return NewWithMetrics(lggr, keystore, cfg, chainID, NewPrometheusMetrics(chainID), getClient, getFeederClient)
 }
 
 func NewWithMetrics(lggr logger.Logger, keystore loop.Keystore, cfg Config, chainID string, metrics TxMetrics, getClient func() (*starknet.Client, error),
@@ -413,12 +413,12 @@ func (txm *starktxm) confirmLoop() {
 							txm.lggr.Errorw("failed to confirm tx in TxStore", "hash", hash, "accountAddress", accountAddress, "error", err)
 						} else {
 							// Increment successful transactions metric
-							txm.metrics.IncrementSuccessfulTransactions(txm.chainID)
+							txm.metrics.IncrementNumSuccessfulTxs()
 						}
 
 						// Increment finalized transactions metric for L1/L2 acceptance
 						if finalityStatus == starknetrpc.TxnStatus_Accepted_On_L1 || finalityStatus == starknetrpc.TxnStatus_Accepted_On_L2 {
-							txm.metrics.IncrementFinalizedTransactions(txm.chainID)
+							txm.metrics.IncrementNumFinalizedTxs()
 						}
 					}
 
@@ -438,7 +438,7 @@ func (txm *starktxm) confirmLoop() {
 						txm.lggr.Errorw("transaction reverted", "hash", hash)
 
 						// Increment reverted transactions metric
-						txm.metrics.IncrementRevertedTransactions(txm.chainID)
+						txm.metrics.IncrementNumRevertedTxs()
 					}
 				}
 			}
@@ -549,7 +549,7 @@ func (txm *starktxm) InflightCount() (queue int, unconfirmed int) {
 
 	// Update tx attempt count metric
 	totalAttempts := queueCount + unconfirmedCount
-	txm.metrics.SetTxAttemptCount(txm.chainID, totalAttempts)
+	txm.metrics.SetTxAttemptCount(totalAttempts)
 
 	return queueCount, unconfirmedCount
 }

--- a/relayer/pkg/chainlink/txm/txm.go
+++ b/relayer/pkg/chainlink/txm/txm.go
@@ -38,14 +38,6 @@ type TxMetrics interface {
 	SetTxAttemptCount(chainID string, count int)
 }
 
-// NoOpTxMetrics is a no-op implementation of TxMetrics for when metrics are not available
-type NoOpTxMetrics struct{}
-
-func (n NoOpTxMetrics) IncrementSuccessfulTransactions(chainID string) {}
-func (n NoOpTxMetrics) IncrementRevertedTransactions(chainID string)   {}
-func (n NoOpTxMetrics) IncrementFinalizedTransactions(chainID string)  {}
-func (n NoOpTxMetrics) SetTxAttemptCount(chainID string, count int)    {}
-
 type Tx struct {
 	publicKey      *felt.Felt
 	accountAddress *felt.Felt

--- a/relayer/pkg/chainlink/txm/txm_integration_test.go
+++ b/relayer/pkg/chainlink/txm/txm_integration_test.go
@@ -33,10 +33,10 @@ func TestIntegration_TXM_Metrics(t *testing.T) {
 
 	// Exercise all metrics to ensure they're registered
 	stxm := txm.(*starktxm)
-	stxm.metrics.IncrementSuccessfulTransactions(chainID)
-	stxm.metrics.IncrementRevertedTransactions(chainID)
-	stxm.metrics.IncrementFinalizedTransactions(chainID)
-	stxm.metrics.SetTxAttemptCount(chainID, 0)
+	stxm.metrics.IncrementNumSuccessfulTxs()
+	stxm.metrics.IncrementNumRevertedTxs()
+	stxm.metrics.IncrementNumFinalizedTxs()
+	stxm.metrics.SetTxAttemptCount(0)
 
 	// Test InflightCount which should also update metrics
 	queue, unconfirmed := txm.InflightCount()

--- a/relayer/pkg/chainlink/txm/txm_integration_test.go
+++ b/relayer/pkg/chainlink/txm/txm_integration_test.go
@@ -13,8 +13,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// TestTXM_MetricsIntegration tests that metrics are actually registered and work
-func TestTXM_MetricsIntegration(t *testing.T) {
+func TestIntegration_TXM_Metrics(t *testing.T) {
 	t.Parallel()
 
 	mockLggr := &mockLogger{Logger: logger.Test(t)}
@@ -72,8 +71,8 @@ func TestTXM_MetricsIntegration(t *testing.T) {
 	assert.Equal(t, 0.0, getMetricValue(t, "tx_manager_tx_attempt_count", chainID))
 }
 
-// TestTXM_InflightCountMetrics tests that InflightCount properly updates metrics
-func TestTXM_InflightCountMetrics(t *testing.T) {
+// TestIntegration_TXM_InflightCountMetrics tests that InflightCount properly updates metrics
+func TestIntegration_TXM_InflightCountMetrics(t *testing.T) {
 	t.Parallel()
 
 	mockLggr := &mockLogger{Logger: logger.Test(t)}

--- a/relayer/pkg/chainlink/txm/txm_integration_test.go
+++ b/relayer/pkg/chainlink/txm/txm_integration_test.go
@@ -1,0 +1,134 @@
+//go:build integration
+
+package txm
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/smartcontractkit/chainlink-common/pkg/logger"
+	"github.com/smartcontractkit/chainlink-starknet/relayer/pkg/starknet"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestTXM_MetricsIntegration tests that metrics are actually registered and work
+func TestTXM_MetricsIntegration(t *testing.T) {
+	t.Parallel()
+
+	mockLggr := &mockLogger{Logger: logger.Test(t)}
+	chainID := "integration-test-chain"
+
+	// Create TXM with real Prometheus metrics
+	txm, err := New(
+		mockLggr,
+		&mockKeystore{},
+		&mockConfig{},
+		chainID,
+		func() (*starknet.Client, error) { return nil, nil },
+		func() (*starknet.FeederClient, error) { return nil, nil },
+	)
+	require.NoError(t, err)
+	require.NotNil(t, txm)
+
+	// Exercise all metrics to ensure they're registered
+	stxm := txm.(*starktxm)
+	stxm.metrics.IncrementSuccessfulTransactions(chainID)
+	stxm.metrics.IncrementRevertedTransactions(chainID)
+	stxm.metrics.IncrementFinalizedTransactions(chainID)
+	stxm.metrics.SetTxAttemptCount(chainID, 0)
+
+	// Test InflightCount which should also update metrics
+	queue, unconfirmed := txm.InflightCount()
+	assert.Equal(t, 0, queue)
+	assert.Equal(t, 0, unconfirmed)
+
+	// Verify all metrics are now registered in Prometheus
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	foundMetrics := map[string]bool{
+		"tx_manager_num_successful_transactions": false,
+		"tx_manager_num_tx_reverted":             false,
+		"tx_manager_tx_attempt_count":            false,
+		"tx_manager_num_finalized_transactions":  false,
+	}
+
+	for _, mf := range metricFamilies {
+		if _, exists := foundMetrics[mf.GetName()]; exists {
+			foundMetrics[mf.GetName()] = true
+		}
+	}
+
+	for metricName, found := range foundMetrics {
+		assert.True(t, found, "Metric %s should be registered", metricName)
+	}
+
+	// Verify actual values
+	assert.Greater(t, getMetricValue(t, "tx_manager_num_successful_transactions", chainID), 0.0)
+	assert.Greater(t, getMetricValue(t, "tx_manager_num_tx_reverted", chainID), 0.0)
+	assert.Greater(t, getMetricValue(t, "tx_manager_num_finalized_transactions", chainID), 0.0)
+	assert.Equal(t, 0.0, getMetricValue(t, "tx_manager_tx_attempt_count", chainID))
+}
+
+// TestTXM_InflightCountMetrics tests that InflightCount properly updates metrics
+func TestTXM_InflightCountMetrics(t *testing.T) {
+	t.Parallel()
+
+	mockLggr := &mockLogger{Logger: logger.Test(t)}
+	chainID := "inflightcount-integration-test"
+
+	txm, err := New(
+		mockLggr,
+		&mockKeystore{},
+		&mockConfig{},
+		chainID,
+		func() (*starknet.Client, error) { return nil, nil },
+		func() (*starknet.FeederClient, error) { return nil, nil },
+	)
+	require.NoError(t, err)
+
+	// Call InflightCount multiple times
+	for i := 0; i < 5; i++ {
+		queue, unconfirmed := txm.InflightCount()
+		assert.Equal(t, 0, queue)
+		assert.Equal(t, 0, unconfirmed)
+	}
+
+	// Verify metric is consistently set
+	finalValue := getMetricValue(t, "tx_manager_tx_attempt_count", chainID)
+	assert.Equal(t, 0.0, finalValue)
+}
+
+// Helper function to get metric value from Prometheus
+func getMetricValue(t *testing.T, metricName, chainID string) float64 {
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range metricFamilies {
+		if mf.GetName() == metricName {
+			for _, m := range mf.GetMetric() {
+				if hasLabelValue(m, "chainID", chainID) {
+					if m.Gauge != nil {
+						return m.GetGauge().GetValue()
+					}
+					if m.Counter != nil {
+						return m.GetCounter().GetValue()
+					}
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// Helper to check if metric has specific label value
+func hasLabelValue(m *dto.Metric, labelName, labelValue string) bool {
+	for _, label := range m.GetLabel() {
+		if label.GetName() == labelName && label.GetValue() == labelValue {
+			return true
+		}
+	}
+	return false
+}

--- a/relayer/pkg/chainlink/txm/txm_metrics.go
+++ b/relayer/pkg/chainlink/txm/txm_metrics.go
@@ -1,51 +1,68 @@
 package txm
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
-	promNumSuccessfulTxs = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "tx_manager_num_successful_transactions",
-		Help: "Total number of successful transactions. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
-	}, []string{"chainID"})
-
-	promRevertedTxCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "tx_manager_num_tx_reverted",
-		Help: "Number of times a transaction reverted on-chain. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
-	}, []string{"chainID"})
-
-	promTxAttemptCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "tx_manager_tx_attempt_count",
-		Help: "The number of transaction attempts that are currently being processed by the transaction manager",
-	}, []string{"chainID"})
-
-	promNumFinalizedTxs = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "tx_manager_num_finalized_transactions",
-		Help: "Total number of finalized transactions (accepted on L1 or L2)",
-	}, []string{"chainID"})
+	promNumSuccessfulTxs *prometheus.CounterVec
+	promRevertedTxCount  *prometheus.CounterVec
+	promTxAttemptCount   *prometheus.GaugeVec
+	promNumFinalizedTxs  *prometheus.CounterVec
+	metricsOnce          sync.Once
 )
+
+func initMetrics() {
+	metricsOnce.Do(func() {
+		promNumSuccessfulTxs = promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "tx_manager_num_successful_transactions",
+			Help: "Total number of successful transactions. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
+		}, []string{"chainID"})
+
+		promRevertedTxCount = promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "tx_manager_num_tx_reverted",
+			Help: "Number of times a transaction reverted on-chain. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
+		}, []string{"chainID"})
+
+		promTxAttemptCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "tx_manager_tx_attempt_count",
+			Help: "The number of transaction attempts that are currently being processed by the transaction manager",
+		}, []string{"chainID"})
+
+		promNumFinalizedTxs = promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "tx_manager_num_finalized_transactions",
+			Help: "Total number of finalized transactions (accepted on L1 or L2)",
+		}, []string{"chainID"})
+	})
+}
 
 // prometheusMetrics implements TxMetrics using Prometheus
 type prometheusMetrics struct{}
 
 func NewPrometheusMetrics() TxMetrics {
+	initMetrics()
 	return &prometheusMetrics{}
 }
 
 func (m *prometheusMetrics) IncrementSuccessfulTransactions(chainID string) {
+	initMetrics()
 	promNumSuccessfulTxs.WithLabelValues(chainID).Inc()
 }
 
 func (m *prometheusMetrics) IncrementRevertedTransactions(chainID string) {
+	initMetrics()
 	promRevertedTxCount.WithLabelValues(chainID).Inc()
 }
 
 func (m *prometheusMetrics) IncrementFinalizedTransactions(chainID string) {
+	initMetrics()
 	promNumFinalizedTxs.WithLabelValues(chainID).Inc()
 }
 
 func (m *prometheusMetrics) SetTxAttemptCount(chainID string, count int) {
+	initMetrics()
 	promTxAttemptCount.WithLabelValues(chainID).Set(float64(count))
 }

--- a/relayer/pkg/chainlink/txm/txm_metrics.go
+++ b/relayer/pkg/chainlink/txm/txm_metrics.go
@@ -1,28 +1,43 @@
 package txm
 
 import (
+	"sync"
+
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
-	promNumSuccessfulTxs = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "tx_manager_num_successful_transactions",
-		Help: "Total number of successful transactions. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
-	}, []string{"chainID"})
-	promRevertedTxCount = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "tx_manager_num_tx_reverted",
-		Help: "Number of times a transaction reverted on-chain. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
-	}, []string{"chainID"})
-	promTxAttemptCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
-		Name: "tx_manager_tx_attempt_count",
-		Help: "The number of transaction attempts that are currently being processed by the transaction manager",
-	}, []string{"chainID"})
-	promNumFinalizedTxs = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "tx_manager_num_finalized_transactions",
-		Help: "Total number of finalized transactions (accepted on L1 or L2)",
-	}, []string{"chainID"})
+	promNumSuccessfulTxs *prometheus.CounterVec
+	promRevertedTxCount  *prometheus.CounterVec
+	promTxAttemptCount   *prometheus.GaugeVec
+	promNumFinalizedTxs  *prometheus.CounterVec
+	metricsOnce          sync.Once
 )
+
+func initMetrics() {
+	metricsOnce.Do(func() {
+		promNumSuccessfulTxs = promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "tx_manager_num_successful_transactions",
+			Help: "Total number of successful transactions. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
+		}, []string{"chainID"})
+
+		promRevertedTxCount = promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "tx_manager_num_tx_reverted",
+			Help: "Number of times a transaction reverted on-chain. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
+		}, []string{"chainID"})
+
+		promTxAttemptCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+			Name: "tx_manager_tx_attempt_count",
+			Help: "The number of transaction attempts that are currently being processed by the transaction manager",
+		}, []string{"chainID"})
+
+		promNumFinalizedTxs = promauto.NewCounterVec(prometheus.CounterOpts{
+			Name: "tx_manager_num_finalized_transactions",
+			Help: "Total number of finalized transactions (accepted on L1 or L2)",
+		}, []string{"chainID"})
+	})
+}
 
 // prometheusMetrics implements TxMetrics using Prometheus
 type prometheusMetrics struct {
@@ -30,21 +45,26 @@ type prometheusMetrics struct {
 }
 
 func NewPrometheusMetrics(chainID string) TxMetrics {
+	initMetrics()
 	return &prometheusMetrics{chainID: chainID}
 }
 
 func (m *prometheusMetrics) IncrementNumSuccessfulTxs() {
+	initMetrics()
 	promNumSuccessfulTxs.WithLabelValues(m.chainID).Inc()
 }
 
 func (m *prometheusMetrics) IncrementNumRevertedTxs() {
+	initMetrics()
 	promRevertedTxCount.WithLabelValues(m.chainID).Inc()
 }
 
 func (m *prometheusMetrics) IncrementNumFinalizedTxs() {
+	initMetrics()
 	promNumFinalizedTxs.WithLabelValues(m.chainID).Inc()
 }
 
 func (m *prometheusMetrics) SetTxAttemptCount(count int) {
+	initMetrics()
 	promTxAttemptCount.WithLabelValues(m.chainID).Set(float64(count))
 }

--- a/relayer/pkg/chainlink/txm/txm_metrics.go
+++ b/relayer/pkg/chainlink/txm/txm_metrics.go
@@ -1,43 +1,28 @@
 package txm
 
 import (
-	"sync"
-
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
 var (
-	promNumSuccessfulTxs *prometheus.CounterVec
-	promRevertedTxCount  *prometheus.CounterVec
-	promTxAttemptCount   *prometheus.GaugeVec
-	promNumFinalizedTxs  *prometheus.CounterVec
-	metricsOnce          sync.Once
+	promNumSuccessfulTxs = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tx_manager_num_successful_transactions",
+		Help: "Total number of successful transactions. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
+	}, []string{"chainID"})
+	promRevertedTxCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tx_manager_num_tx_reverted",
+		Help: "Number of times a transaction reverted on-chain. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
+	}, []string{"chainID"})
+	promTxAttemptCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tx_manager_tx_attempt_count",
+		Help: "The number of transaction attempts that are currently being processed by the transaction manager",
+	}, []string{"chainID"})
+	promNumFinalizedTxs = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tx_manager_num_finalized_transactions",
+		Help: "Total number of finalized transactions (accepted on L1 or L2)",
+	}, []string{"chainID"})
 )
-
-func initMetrics() {
-	metricsOnce.Do(func() {
-		promNumSuccessfulTxs = promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "tx_manager_num_successful_transactions",
-			Help: "Total number of successful transactions. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
-		}, []string{"chainID"})
-
-		promRevertedTxCount = promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "tx_manager_num_tx_reverted",
-			Help: "Number of times a transaction reverted on-chain. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
-		}, []string{"chainID"})
-
-		promTxAttemptCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
-			Name: "tx_manager_tx_attempt_count",
-			Help: "The number of transaction attempts that are currently being processed by the transaction manager",
-		}, []string{"chainID"})
-
-		promNumFinalizedTxs = promauto.NewCounterVec(prometheus.CounterOpts{
-			Name: "tx_manager_num_finalized_transactions",
-			Help: "Total number of finalized transactions (accepted on L1 or L2)",
-		}, []string{"chainID"})
-	})
-}
 
 // prometheusMetrics implements TxMetrics using Prometheus
 type prometheusMetrics struct {
@@ -45,26 +30,21 @@ type prometheusMetrics struct {
 }
 
 func NewPrometheusMetrics(chainID string) TxMetrics {
-	initMetrics()
 	return &prometheusMetrics{chainID: chainID}
 }
 
 func (m *prometheusMetrics) IncrementNumSuccessfulTxs() {
-	initMetrics()
 	promNumSuccessfulTxs.WithLabelValues(m.chainID).Inc()
 }
 
 func (m *prometheusMetrics) IncrementNumRevertedTxs() {
-	initMetrics()
 	promRevertedTxCount.WithLabelValues(m.chainID).Inc()
 }
 
 func (m *prometheusMetrics) IncrementNumFinalizedTxs() {
-	initMetrics()
 	promNumFinalizedTxs.WithLabelValues(m.chainID).Inc()
 }
 
 func (m *prometheusMetrics) SetTxAttemptCount(count int) {
-	initMetrics()
 	promTxAttemptCount.WithLabelValues(m.chainID).Set(float64(count))
 }

--- a/relayer/pkg/chainlink/txm/txm_metrics.go
+++ b/relayer/pkg/chainlink/txm/txm_metrics.go
@@ -40,29 +40,31 @@ func initMetrics() {
 }
 
 // prometheusMetrics implements TxMetrics using Prometheus
-type prometheusMetrics struct{}
-
-func NewPrometheusMetrics() TxMetrics {
-	initMetrics()
-	return &prometheusMetrics{}
+type prometheusMetrics struct {
+	chainID string
 }
 
-func (m *prometheusMetrics) IncrementSuccessfulTransactions(chainID string) {
+func NewPrometheusMetrics(chainID string) TxMetrics {
 	initMetrics()
-	promNumSuccessfulTxs.WithLabelValues(chainID).Inc()
+	return &prometheusMetrics{chainID: chainID}
 }
 
-func (m *prometheusMetrics) IncrementRevertedTransactions(chainID string) {
+func (m *prometheusMetrics) IncrementNumSuccessfulTxs() {
 	initMetrics()
-	promRevertedTxCount.WithLabelValues(chainID).Inc()
+	promNumSuccessfulTxs.WithLabelValues(m.chainID).Inc()
 }
 
-func (m *prometheusMetrics) IncrementFinalizedTransactions(chainID string) {
+func (m *prometheusMetrics) IncrementNumRevertedTxs() {
 	initMetrics()
-	promNumFinalizedTxs.WithLabelValues(chainID).Inc()
+	promRevertedTxCount.WithLabelValues(m.chainID).Inc()
 }
 
-func (m *prometheusMetrics) SetTxAttemptCount(chainID string, count int) {
+func (m *prometheusMetrics) IncrementNumFinalizedTxs() {
 	initMetrics()
-	promTxAttemptCount.WithLabelValues(chainID).Set(float64(count))
+	promNumFinalizedTxs.WithLabelValues(m.chainID).Inc()
+}
+
+func (m *prometheusMetrics) SetTxAttemptCount(count int) {
+	initMetrics()
+	promTxAttemptCount.WithLabelValues(m.chainID).Set(float64(count))
 }

--- a/relayer/pkg/chainlink/txm/txm_metrics.go
+++ b/relayer/pkg/chainlink/txm/txm_metrics.go
@@ -1,0 +1,51 @@
+package txm
+
+import (
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/promauto"
+)
+
+var (
+	promNumSuccessfulTxs = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tx_manager_num_successful_transactions",
+		Help: "Total number of successful transactions. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
+	}, []string{"chainID"})
+
+	promRevertedTxCount = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tx_manager_num_tx_reverted",
+		Help: "Number of times a transaction reverted on-chain. Note that this can err to be too high since transactions are counted on each confirmation, which can happen multiple times per transaction in the case of re-orgs",
+	}, []string{"chainID"})
+
+	promTxAttemptCount = promauto.NewGaugeVec(prometheus.GaugeOpts{
+		Name: "tx_manager_tx_attempt_count",
+		Help: "The number of transaction attempts that are currently being processed by the transaction manager",
+	}, []string{"chainID"})
+
+	promNumFinalizedTxs = promauto.NewCounterVec(prometheus.CounterOpts{
+		Name: "tx_manager_num_finalized_transactions",
+		Help: "Total number of finalized transactions (accepted on L1 or L2)",
+	}, []string{"chainID"})
+)
+
+// prometheusMetrics implements TxMetrics using Prometheus
+type prometheusMetrics struct{}
+
+func NewPrometheusMetrics() TxMetrics {
+	return &prometheusMetrics{}
+}
+
+func (m *prometheusMetrics) IncrementSuccessfulTransactions(chainID string) {
+	promNumSuccessfulTxs.WithLabelValues(chainID).Inc()
+}
+
+func (m *prometheusMetrics) IncrementRevertedTransactions(chainID string) {
+	promRevertedTxCount.WithLabelValues(chainID).Inc()
+}
+
+func (m *prometheusMetrics) IncrementFinalizedTransactions(chainID string) {
+	promNumFinalizedTxs.WithLabelValues(chainID).Inc()
+}
+
+func (m *prometheusMetrics) SetTxAttemptCount(chainID string, count int) {
+	promTxAttemptCount.WithLabelValues(chainID).Set(float64(count))
+}

--- a/relayer/pkg/chainlink/txm/txm_metrics_test.go
+++ b/relayer/pkg/chainlink/txm/txm_metrics_test.go
@@ -13,12 +13,12 @@ func TestPrometheusMetrics_Registration(t *testing.T) {
 	// Note: Cannot use t.Parallel() because we need to ensure metrics are initialized
 
 	// Initialize metrics by calling them once (promauto registers on first use)
-	metrics := NewPrometheusMetrics()
 	testChainID := "test-registration"
-	metrics.IncrementSuccessfulTransactions(testChainID)
-	metrics.IncrementRevertedTransactions(testChainID)
-	metrics.IncrementFinalizedTransactions(testChainID)
-	metrics.SetTxAttemptCount(testChainID, 1)
+	metrics := NewPrometheusMetrics(testChainID)
+	metrics.IncrementNumSuccessfulTxs()
+	metrics.IncrementNumRevertedTxs()
+	metrics.IncrementNumFinalizedTxs()
+	metrics.SetTxAttemptCount(1)
 
 	// Test that all metrics are registered with Prometheus
 	metricFamilies, err := prometheus.DefaultGatherer.Gather()
@@ -46,7 +46,7 @@ func TestNewPrometheusMetrics(t *testing.T) {
 	t.Parallel()
 
 	// Test that NewPrometheusMetrics returns a valid instance
-	metrics := NewPrometheusMetrics()
+	metrics := NewPrometheusMetrics("test-chain")
 	require.NotNil(t, metrics)
 
 	// Verify it implements TxMetrics interface
@@ -57,15 +57,15 @@ func TestPrometheusMetrics_ImplementsInterface(t *testing.T) {
 	t.Parallel()
 
 	// Compile-time check that prometheusMetrics implements TxMetrics
-	var _ TxMetrics = &prometheusMetrics{}
+	var _ TxMetrics = &prometheusMetrics{chainID: "test"}
 	var _ TxMetrics = (*prometheusMetrics)(nil)
 }
 
 func TestPrometheusMetrics_Increment(t *testing.T) {
 	t.Parallel()
 
-	metrics := NewPrometheusMetrics()
 	chainID := "test-chain-increment"
+	metrics := NewPrometheusMetrics(chainID)
 
 	// Get initial values
 	initialSuccessful := getCounterValue(t, "tx_manager_num_successful_transactions", chainID)
@@ -73,12 +73,12 @@ func TestPrometheusMetrics_Increment(t *testing.T) {
 	initialFinalized := getCounterValue(t, "tx_manager_num_finalized_transactions", chainID)
 
 	// Increment metrics
-	metrics.IncrementSuccessfulTransactions(chainID)
-	metrics.IncrementSuccessfulTransactions(chainID)
-	metrics.IncrementRevertedTransactions(chainID)
-	metrics.IncrementFinalizedTransactions(chainID)
-	metrics.IncrementFinalizedTransactions(chainID)
-	metrics.IncrementFinalizedTransactions(chainID)
+	metrics.IncrementNumSuccessfulTxs()
+	metrics.IncrementNumSuccessfulTxs()
+	metrics.IncrementNumRevertedTxs()
+	metrics.IncrementNumFinalizedTxs()
+	metrics.IncrementNumFinalizedTxs()
+	metrics.IncrementNumFinalizedTxs()
 
 	// Verify increments
 	finalSuccessful := getCounterValue(t, "tx_manager_num_successful_transactions", chainID)
@@ -93,16 +93,16 @@ func TestPrometheusMetrics_Increment(t *testing.T) {
 func TestPrometheusMetrics_SetGauge(t *testing.T) {
 	t.Parallel()
 
-	metrics := NewPrometheusMetrics()
 	chainID := "test-chain-gauge"
+	metrics := NewPrometheusMetrics(chainID)
 
 	// Set gauge values
-	metrics.SetTxAttemptCount(chainID, 42)
+	metrics.SetTxAttemptCount(42)
 	value := getGaugeValue(t, "tx_manager_tx_attempt_count", chainID)
 	assert.Equal(t, 42.0, value, "Gauge should be set to 42")
 
 	// Update gauge
-	metrics.SetTxAttemptCount(chainID, 100)
+	metrics.SetTxAttemptCount(100)
 	value = getGaugeValue(t, "tx_manager_tx_attempt_count", chainID)
 	assert.Equal(t, 100.0, value, "Gauge should be updated to 100")
 }
@@ -110,18 +110,20 @@ func TestPrometheusMetrics_SetGauge(t *testing.T) {
 func TestPrometheusMetrics_MultipleChains(t *testing.T) {
 	t.Parallel()
 
-	metrics := NewPrometheusMetrics()
 	chain1 := "chain-1-multi"
 	chain2 := "chain-2-multi"
+
+	metrics1 := NewPrometheusMetrics(chain1)
+	metrics2 := NewPrometheusMetrics(chain2)
 
 	// Get initial values
 	initialChain1 := getCounterValue(t, "tx_manager_num_successful_transactions", chain1)
 	initialChain2 := getCounterValue(t, "tx_manager_num_successful_transactions", chain2)
 
 	// Increment different chains
-	metrics.IncrementSuccessfulTransactions(chain1)
-	metrics.IncrementSuccessfulTransactions(chain1)
-	metrics.IncrementSuccessfulTransactions(chain2)
+	metrics1.IncrementNumSuccessfulTxs()
+	metrics1.IncrementNumSuccessfulTxs()
+	metrics2.IncrementNumSuccessfulTxs()
 
 	// Verify separate tracking
 	finalChain1 := getCounterValue(t, "tx_manager_num_successful_transactions", chain1)

--- a/relayer/pkg/chainlink/txm/txm_metrics_test.go
+++ b/relayer/pkg/chainlink/txm/txm_metrics_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestPrometheusMetrics_Registration(t *testing.T) {
-	t.Parallel()
+	// Note: Cannot use t.Parallel() because we need to ensure metrics are initialized
 
 	// Initialize metrics by calling them once (promauto registers on first use)
 	metrics := NewPrometheusMetrics()
@@ -40,6 +40,25 @@ func TestPrometheusMetrics_Registration(t *testing.T) {
 	for metricName, found := range metricsFound {
 		assert.True(t, found, "Metric %s should be registered with Prometheus", metricName)
 	}
+}
+
+func TestNewPrometheusMetrics(t *testing.T) {
+	t.Parallel()
+
+	// Test that NewPrometheusMetrics returns a valid instance
+	metrics := NewPrometheusMetrics()
+	require.NotNil(t, metrics)
+
+	// Verify it implements TxMetrics interface
+	var _ TxMetrics = metrics
+}
+
+func TestPrometheusMetrics_ImplementsInterface(t *testing.T) {
+	t.Parallel()
+
+	// Compile-time check that prometheusMetrics implements TxMetrics
+	var _ TxMetrics = &prometheusMetrics{}
+	var _ TxMetrics = (*prometheusMetrics)(nil)
 }
 
 func TestPrometheusMetrics_Increment(t *testing.T) {

--- a/relayer/pkg/chainlink/txm/txm_metrics_test.go
+++ b/relayer/pkg/chainlink/txm/txm_metrics_test.go
@@ -1,0 +1,157 @@
+package txm
+
+import (
+	"testing"
+
+	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPrometheusMetrics_Registration(t *testing.T) {
+	t.Parallel()
+
+	// Initialize metrics by calling them once (promauto registers on first use)
+	metrics := NewPrometheusMetrics()
+	testChainID := "test-registration"
+	metrics.IncrementSuccessfulTransactions(testChainID)
+	metrics.IncrementRevertedTransactions(testChainID)
+	metrics.IncrementFinalizedTransactions(testChainID)
+	metrics.SetTxAttemptCount(testChainID, 1)
+
+	// Test that all metrics are registered with Prometheus
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	metricsFound := map[string]bool{
+		"tx_manager_num_successful_transactions": false,
+		"tx_manager_num_tx_reverted":             false,
+		"tx_manager_tx_attempt_count":            false,
+		"tx_manager_num_finalized_transactions":  false,
+	}
+
+	for _, mf := range metricFamilies {
+		if _, exists := metricsFound[mf.GetName()]; exists {
+			metricsFound[mf.GetName()] = true
+		}
+	}
+
+	for metricName, found := range metricsFound {
+		assert.True(t, found, "Metric %s should be registered with Prometheus", metricName)
+	}
+}
+
+func TestPrometheusMetrics_Increment(t *testing.T) {
+	t.Parallel()
+
+	metrics := NewPrometheusMetrics()
+	chainID := "test-chain-increment"
+
+	// Get initial values
+	initialSuccessful := getCounterValue(t, "tx_manager_num_successful_transactions", chainID)
+	initialReverted := getCounterValue(t, "tx_manager_num_tx_reverted", chainID)
+	initialFinalized := getCounterValue(t, "tx_manager_num_finalized_transactions", chainID)
+
+	// Increment metrics
+	metrics.IncrementSuccessfulTransactions(chainID)
+	metrics.IncrementSuccessfulTransactions(chainID)
+	metrics.IncrementRevertedTransactions(chainID)
+	metrics.IncrementFinalizedTransactions(chainID)
+	metrics.IncrementFinalizedTransactions(chainID)
+	metrics.IncrementFinalizedTransactions(chainID)
+
+	// Verify increments
+	finalSuccessful := getCounterValue(t, "tx_manager_num_successful_transactions", chainID)
+	finalReverted := getCounterValue(t, "tx_manager_num_tx_reverted", chainID)
+	finalFinalized := getCounterValue(t, "tx_manager_num_finalized_transactions", chainID)
+
+	assert.Equal(t, initialSuccessful+2, finalSuccessful, "Successful transactions should increment by 2")
+	assert.Equal(t, initialReverted+1, finalReverted, "Reverted transactions should increment by 1")
+	assert.Equal(t, initialFinalized+3, finalFinalized, "Finalized transactions should increment by 3")
+}
+
+func TestPrometheusMetrics_SetGauge(t *testing.T) {
+	t.Parallel()
+
+	metrics := NewPrometheusMetrics()
+	chainID := "test-chain-gauge"
+
+	// Set gauge values
+	metrics.SetTxAttemptCount(chainID, 42)
+	value := getGaugeValue(t, "tx_manager_tx_attempt_count", chainID)
+	assert.Equal(t, 42.0, value, "Gauge should be set to 42")
+
+	// Update gauge
+	metrics.SetTxAttemptCount(chainID, 100)
+	value = getGaugeValue(t, "tx_manager_tx_attempt_count", chainID)
+	assert.Equal(t, 100.0, value, "Gauge should be updated to 100")
+}
+
+func TestPrometheusMetrics_MultipleChains(t *testing.T) {
+	t.Parallel()
+
+	metrics := NewPrometheusMetrics()
+	chain1 := "chain-1-multi"
+	chain2 := "chain-2-multi"
+
+	// Get initial values
+	initialChain1 := getCounterValue(t, "tx_manager_num_successful_transactions", chain1)
+	initialChain2 := getCounterValue(t, "tx_manager_num_successful_transactions", chain2)
+
+	// Increment different chains
+	metrics.IncrementSuccessfulTransactions(chain1)
+	metrics.IncrementSuccessfulTransactions(chain1)
+	metrics.IncrementSuccessfulTransactions(chain2)
+
+	// Verify separate tracking
+	finalChain1 := getCounterValue(t, "tx_manager_num_successful_transactions", chain1)
+	finalChain2 := getCounterValue(t, "tx_manager_num_successful_transactions", chain2)
+
+	assert.Equal(t, initialChain1+2, finalChain1, "Chain 1 should increment by 2")
+	assert.Equal(t, initialChain2+1, finalChain2, "Chain 2 should increment by 1")
+}
+
+// Helper function to get counter value from Prometheus
+func getCounterValue(t *testing.T, metricName, chainID string) float64 {
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range metricFamilies {
+		if mf.GetName() == metricName {
+			for _, m := range mf.GetMetric() {
+				if hasLabel(m, "chainID", chainID) {
+					return m.GetCounter().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// Helper function to get gauge value from Prometheus
+func getGaugeValue(t *testing.T, metricName, chainID string) float64 {
+	metricFamilies, err := prometheus.DefaultGatherer.Gather()
+	require.NoError(t, err)
+
+	for _, mf := range metricFamilies {
+		if mf.GetName() == metricName {
+			for _, m := range mf.GetMetric() {
+				if hasLabel(m, "chainID", chainID) {
+					return m.GetGauge().GetValue()
+				}
+			}
+		}
+	}
+	return 0
+}
+
+// Helper function to check if metric has a specific label value
+func hasLabel(m *dto.Metric, labelName, labelValue string) bool {
+	for _, label := range m.GetLabel() {
+		if label.GetName() == labelName && label.GetValue() == labelValue {
+			return true
+		}
+	}
+	return false
+}

--- a/relayer/pkg/chainlink/txm/txm_test.go
+++ b/relayer/pkg/chainlink/txm/txm_test.go
@@ -77,7 +77,7 @@ func TestIntegration_Txm(t *testing.T) {
 	cfg.On("TxTimeout").Return(20 * time.Second)
 	cfg.On("ConfirmationPoll").Return(1 * time.Second)
 
-	txm, err := New(lggr, ksAdapter.Loopp(), cfg, getClient, getFeederClient)
+	txm, err := New(lggr, ksAdapter.Loopp(), cfg, "test-chain", getClient, getFeederClient)
 	require.NoError(t, err)
 
 	// ready fail if start not called


### PR DESCRIPTION
## Summary

Adds Prometheus metrics to the Starknet transaction manager for monitoring transaction success rates and queue depth. Matches the metrics already used in chainlink-evm.

## What changed

Added 4 metrics:
- `tx_manager_num_successful_transactions`
- `tx_manager_num_tx_reverted` 
- `tx_manager_num_finalized_transactions`
- `tx_manager_tx_attempt_count`

Used `sync.Once` to avoid duplicate registration issues when the TXM is imported by multiple packages.