### PR TITLE
chore(ci): github actions maintenance

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       # Checkout this repository
       - name: Checkout Repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -68,7 +68,7 @@ jobs:
         id: setup-github-token
         uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
         with:
-          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
       - name: Setup Go with private repo access
@@ -107,7 +107,7 @@ jobs:
         id: setup-github-token
         uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
         with:
-          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
       - name: Setup Go with private repo access

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install Nix
@@ -33,7 +33,7 @@ jobs:
     needs: [golangci-lint-version]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install Nix
@@ -61,7 +61,7 @@ jobs:
     needs: [golangci-lint-version]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Setup GitHub Token
@@ -100,7 +100,7 @@ jobs:
     needs: [golangci-lint-version]
     steps:
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Setup GitHub Token

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -66,7 +66,7 @@ jobs:
           persist-credentials: false
       - name: Setup GitHub Token
         id: setup-github-token
-        uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}
@@ -105,7 +105,7 @@ jobs:
           persist-credentials: false
       - name: Setup GitHub Token
         id: setup-github-token
-        uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -47,7 +47,7 @@ jobs:
         run: cat ./relayer/golangci-lint-relayer-report.xml
       - name: Store Golangci lint relayer report artifact
         if: always()
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: golangci-lint-relayer-report
           path: ./relayer/golangci-lint-relayer-report.xml
@@ -86,7 +86,7 @@ jobs:
         run: cat ./ops/golangci-lint-ops-report.xml
       - name: Store Golangci lint ops report artifact
         if: always()
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: golangci-lint-ops-report
           path: ./ops/golangci-lint-ops-report.xml
@@ -125,7 +125,7 @@ jobs:
         run: cat ./integration-tests/golangci-lint-integration-tests-report.xml
       - name: Store Golangci lint integration tests report artifact
         if: always()
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: golangci-lint-integration-tests-report
           path: ./integration-tests/golangci-lint-integration-tests-report.xml

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -18,16 +18,6 @@ jobs:
     name: Publish Integration Test Image
     runs-on: ubuntu-latest
     steps:
-      - name: Collect Metrics
-        id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
-        with:
-          id: starknet-e2e-publish
-          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-          this-job-name: Publish Integration Test Image
-        continue-on-error: true
       - name: Checkout the repo
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -29,7 +29,7 @@ jobs:
           this-job-name: Publish Integration Test Image
         continue-on-error: true
       - name: Checkout the repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Setup GitHub Token

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -34,7 +34,7 @@ jobs:
           persist-credentials: false
       - name: Setup GitHub Token
         id: setup-github-token
-        uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -36,7 +36,7 @@ jobs:
         id: setup-github-token
         uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
         with:
-          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
       - name: Build Image

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -36,16 +36,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Collect Metrics
-        id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
-        with:
-          id: starknet-e2e-build
-          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-          this-job-name: Build Chainlink Image
-        continue-on-error: true
       - name: Check if chainlink-starknet image exists
         id: check-image
         uses: smartcontractkit/chainlink-github-actions/docker/image-exists@fc3e0df622521019f50d772726d6bf8dc919dd38 # v2.3.19
@@ -97,16 +87,6 @@ jobs:
     name: Build Test Image
     runs-on: ubuntu20.04-32cores-128GB
     steps:
-      - name: Collect Metrics
-        id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
-        with:
-          id: starknet-e2e-build-test-image
-          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-          this-job-name: Build Test Image
-        continue-on-error: true
       - name: Setup GitHub Token
         id: setup-github-token
         uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
@@ -140,17 +120,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Collect Metrics
-        id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
-        with:
-          id: starknet-e2e-smoke
-          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-          this-job-name: Run Smoke Tests
-          test-results-file: '{"testType":"go","filePath":"/tmp/gotest.log"}'
-        continue-on-error: true
       - name: Checkout the repo
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -109,7 +109,7 @@ jobs:
         continue-on-error: true
       - name: Setup GitHub Token
         id: setup-github-token
-        uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}
@@ -163,7 +163,7 @@ jobs:
         uses: ./.github/actions/install-cairo
       - name: Setup GitHub Token
         id: setup-github-token
-        uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # 0.2.1
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -85,7 +85,7 @@ jobs:
       id-token: write
       contents: read
     name: Build Test Image
-    runs-on: ubuntu20.04-32cores-128GB
+    runs-on: ubuntu24.04-32cores-128GB
     steps:
       - name: Setup GitHub Token
         id: setup-github-token
@@ -109,7 +109,7 @@ jobs:
 
   run_tests:
     name: Run Smoke Tests
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu24.04-16cores-64GB
     needs: [build_chainlink_image, build_test_image]
     environment: integration
     env:

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -12,7 +12,7 @@ on:
       team:
         description: Team to run the tests for (e.g. BIX, CCIP)
         required: true
-        type: string          
+        type: string
 
 # Only run 1 of this workflow at a time per PR
 concurrency:
@@ -111,7 +111,7 @@ jobs:
         id: setup-github-token
         uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
         with:
-          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
       - name: Checkout the repo
@@ -130,7 +130,7 @@ jobs:
   run_tests:
     name: Run Smoke Tests
     runs-on: ubuntu20.04-16cores-64GB
-    needs: [ build_chainlink_image, build_test_image ]
+    needs: [build_chainlink_image, build_test_image]
     environment: integration
     env:
       INTERNAL_DOCKER_REPO: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
@@ -165,7 +165,7 @@ jobs:
         id: setup-github-token
         uses: smartcontractkit/.github/actions/setup-github-token@ef78fa97bf3c77de6563db1175422703e9e6674f # 0.2.1
         with:
-          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
       - name: Build contracts
@@ -175,7 +175,8 @@ jobs:
         run: |
           yarn install && yarn build
       - name: Generate config overrides
-        run: | # https://github.com/smartcontractkit/chainlink-testing-framework/blob/main/config/README.md
+        run:
+          | # https://github.com/smartcontractkit/chainlink-testing-framework/blob/main/config/README.md
           cat << EOF > config.toml
           [Network]
           selected_networks=["SIMULATED"]

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -115,7 +115,7 @@ jobs:
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
       - name: Checkout the repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.sha }}
           persist-credentials: false
@@ -152,7 +152,7 @@ jobs:
           test-results-file: '{"testType":"go","filePath":"/tmp/gotest.log"}'
         continue-on-error: true
       - name: Checkout the repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install Nix

--- a/.github/workflows/integration-tests-soak.yml
+++ b/.github/workflows/integration-tests-soak.yml
@@ -52,7 +52,7 @@ jobs:
           test-results-file: '{"testType":"go","filePath":"/tmp/gotest.log"}'
         continue-on-error: true
       - name: Checkout the repo
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install Nix

--- a/.github/workflows/integration-tests-soak.yml
+++ b/.github/workflows/integration-tests-soak.yml
@@ -18,7 +18,7 @@ on:
       team:
         description: Team to run the tests for (e.g. BIX, CCIP)
         required: true
-        type: string          
+        type: string
 
 env:
   TEST_LOG_LEVEL: debug
@@ -65,7 +65,7 @@ jobs:
         id: setup-github-token
         uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
         with:
-          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
       - name: Build contracts

--- a/.github/workflows/integration-tests-soak.yml
+++ b/.github/workflows/integration-tests-soak.yml
@@ -40,17 +40,6 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - name: Collect Metrics
-        id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
-        with:
-          id: starknet-e2e-soak
-          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-          this-job-name: Run soak Tests
-          test-results-file: '{"testType":"go","filePath":"/tmp/gotest.log"}'
-        continue-on-error: true
       - name: Checkout the repo
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/integration-tests-soak.yml
+++ b/.github/workflows/integration-tests-soak.yml
@@ -63,7 +63,7 @@ jobs:
         uses: ./.github/actions/install-cairo
       - name: Setup GitHub Token
         id: setup-github-token
-        uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}

--- a/.github/workflows/integration-tests-soak.yml
+++ b/.github/workflows/integration-tests-soak.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   run_tests:
     name: Run soak Tests
-    runs-on: ubuntu20.04-16cores-64GB
+    runs-on: ubuntu24.04-16cores-64GB
     environment: integration
     env:
       TEST_SUITE: soak

--- a/.github/workflows/integration_gauntlet.yml
+++ b/.github/workflows/integration_gauntlet.yml
@@ -31,7 +31,7 @@ jobs:
       - run: nix develop -c yarn eslint
       - name: Upload eslint report
         if: always()
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3 # v4.3.1
+        uses: actions/upload-artifact@v4
         with:
           name: gauntlet-eslint-report
           path: ./eslint-report.json

--- a/.github/workflows/integration_gauntlet.yml
+++ b/.github/workflows/integration_gauntlet.yml
@@ -40,15 +40,6 @@ jobs:
     name: Run Integration Gauntlet Tests
     runs-on: ubuntu-latest
     steps:
-      - name: Collect Metrics
-        id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
-        with:
-          id: starknet-integration-gauntlet
-          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-          this-job-name: Run Integration Gauntlet Tests
       - name: Checkout sources
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/integration_gauntlet.yml
+++ b/.github/workflows/integration_gauntlet.yml
@@ -14,7 +14,7 @@ jobs:
       CI: true
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install Nix
@@ -26,7 +26,7 @@ jobs:
         uses: cachix/cachix-action@ad2ddac53f961de1989924296a1f236fcfbaa4fc
         with:
           name: chainlink-cosmos
-          authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
       - run: nix develop -c yarn install --frozen-lockfile
       - run: nix develop -c yarn eslint
       - name: Upload eslint report
@@ -50,7 +50,7 @@ jobs:
           hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
           this-job-name: Run Integration Gauntlet Tests
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/monitoring-build-push-ecr.yml
+++ b/.github/workflows/monitoring-build-push-ecr.yml
@@ -17,7 +17,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 

--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -34,7 +34,7 @@ jobs:
           this-job-name: Run Unit Tests ${{ matrix.test-type.name }}
           test-results-file: '{"testType":"go","filePath":"/tmp/gotest.log"}'
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Install Nix
@@ -66,7 +66,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       - name: Set up Go

--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Run ${{ matrix.test-type.name }}
         run: nix develop -c sh -c "make ${{ matrix.test-type.name }} LOG_PATH=/tmp/gotest.log"
-      
+
       - name: Upload Golangci relayer results
         if: always()
         uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
@@ -77,7 +77,7 @@ jobs:
         id: setup-github-token
         uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
         with:
-          aws-role-arn: ${{ secrets.AWS_OIDC_GLOBAL_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
+          aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
       - name: Setup Go with private repo access

--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -75,7 +75,7 @@ jobs:
           go-version-file: "relayer/go.mod"
       - name: Setup GitHub Token
         id: setup-github-token
-        uses: smartcontractkit/.github/actions/setup-github-token@9e7cc0779934cae4a9028b8588c9adb64d8ce68c # setup-github-token@0.1.2
+        uses: smartcontractkit/.github/actions/setup-github-token@setup-github-token/v1
         with:
           aws-role-arn: ${{ secrets.AWS_OIDC_CHAINLINK_READ_ONLY_TOKEN_ISSUER_ROLE_ARN }}
           aws-lambda-url: ${{ secrets.GATI_RELENG_LAMBDA_URL }}

--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload Golangci relayer results
         if: always()
-        uses: actions/upload-artifact@5d5d22a31266ced268874388b861e4b58bb5c2f3
+        uses: actions/upload-artifact@v4
         with:
           name: go-unit-tests-results-${{ matrix.test-type.id }}
           path: |

--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -22,17 +22,6 @@ jobs:
           - name: test-integration-go
             id: integration
     steps:
-      - name: Collect Metrics
-        if: matrix.test-type.id != 'race'
-        id: collect-gha-metrics
-        uses: smartcontractkit/push-gha-metrics-action@d9da21a2747016b3e13de58c7d4115a3d5c97935 # v3.0.1
-        with:
-          id: starknet-relay-unit-${{ matrix.test-type.id }}
-          org-id: ${{ secrets.GRAFANA_INTERNAL_TENANT_ID }}
-          basic-auth: ${{ secrets.GRAFANA_INTERNAL_BASIC_AUTH }}
-          hostname: ${{ secrets.GRAFANA_INTERNAL_HOST }}
-          this-job-name: Run Unit Tests ${{ matrix.test-type.name }}
-          test-results-file: '{"testType":"go","filePath":"/tmp/gotest.log"}'
       - name: Checkout sources
         uses: actions/checkout@v5
         with:

--- a/.github/workflows/release/starknet-gauntlet-cli.yml
+++ b/.github/workflows/release/starknet-gauntlet-cli.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       # Checkout this repository
       - name: Checkout Repo
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       # Install nix

--- a/.github/workflows/release/starknet-relayer.yml
+++ b/.github/workflows/release/starknet-relayer.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       # Checkout this repository
       - name: Checkout Repo
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
       # Store starknet version

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -10,7 +10,7 @@ jobs:
     if: always()
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@v5
         with:
           ref: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
           persist-credentials: false
@@ -29,12 +29,12 @@ jobs:
 
   sonarqube:
     name: SonarQube Scan
-    needs: [ wait_for_workflows ]
+    needs: [wait_for_workflows]
     runs-on: ubuntu-latest
     if: always()
     steps:
       - name: Checkout the repo
-        uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0 # fetches all history for all tags and branches to provide more metadata for sonar reports
           persist-credentials: false
@@ -46,7 +46,7 @@ jobs:
           name_is_regexp: true
           name: go-unit-tests-results
           if_no_artifact_found: warn
-     
+
       - name: Download Golangci Relayer report
         uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:
@@ -64,7 +64,7 @@ jobs:
           name_is_regexp: true
           name: golangci-lint-ops-report
           if_no_artifact_found: warn
-      
+
       - name: Download Golangci-lint Integration tests report
         uses: dawidd6/action-download-artifact@bf251b5aa9c2f7eeb574a96ee720e24f801b7c11 # v6
         with:

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+        uses: actions/checkout@v5
         with:
           persist-credentials: false
 


### PR DESCRIPTION
### Changes

* Switch to a new read-only GATI role (DX-1171)
* Bump many `actions/*` actions to a major version tag
* Remove references to deprecated action `push-gha-metrics-action` (RE-3108)
* Bump ubuntu20 runners to ubuntu24


### Motivation

See DX-1171 for more information, but we need to shard the "global" read-only GATI role as it was full. A role dedicated to `chainlink` prefixed repos now exist, and this falls into that category.

Rest of the things are just general maintenance.

---

DX-1171

