### PR TITLE
bump ctf-build-image for platform option

### DIFF
--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -21,7 +21,7 @@ concurrency:
 
 env:
   TEST_LOG_LEVEL: debug
-  CL_ECR: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink
+  CL_ECR: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
   ENV_JOB_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-starknet-tests:${{ github.sha }}
   GAUNTLET_PP_IMAGE: ${{ secrets.PROD_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.PROD_AWS_REGION }}.amazonaws.com/gauntlet-plus-plus:v2.5.0
 
@@ -60,20 +60,28 @@ jobs:
           echo "CUSTOM_CORE_REF=${CL_REF}" >> "${GITHUB_ENV}"
         env:
           CL_REF: ${{ github.event.inputs.cl_branch_ref }}
+      - name: Checkout the repo
+        if: steps.check-image.outputs.exists == 'false'
+        uses: actions/checkout@v5
+        with:
+          repository: smartcontractkit/chainlink
+          ref: ${{ env.CUSTOM_CORE_REF }}
+          persist-credentials: false
       - name: Build Image
         if: steps.check-image.outputs.exists == 'false'
-        uses: smartcontractkit/.github/actions/ctf-build-image@7b28f2c598c26a8a0af8818b64d5344247752c71 # v0.1.3
+        uses: smartcontractkit/.github/actions/ctf-build-image@1d86ef6568d0830d212fc0091d352170dae07dc7 # v1.2.0
         with:
-          cl_repo: smartcontractkit/chainlink
-          cl_ref: ${{ env.CUSTOM_CORE_REF }}
-          should_checkout: true
-          cl_dockerfile: plugins/chainlink.Dockerfile
-          # commit of the caller branch
-          dep_starknet_sha: ${{ github.event.pull_request.head.sha || github.sha }}
-          push_tag: ${{ env.CL_ECR }}:starknet.${{ github.sha }}
-          QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
-          QA_AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
-          QA_PRIVATE_GHA_PULL: ${{ secrets.QA_PRIVATE_GHA_PULL }}
+          platform: "linux/arm64"
+          dockerfile: plugins/chainlink.Dockerfile
+          plugin-manifest-overrides: |
+            starknet=${{ github.event.pull_request.head.sha || github.sha }}
+          # registry info
+          docker-registry-url: ${{ env.CL_ECR }}
+          docker-repository-name: chainlink
+          image-tag: starknet.${{ github.sha }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
+          aws-role-arn: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+          aws-account-number: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
       - name: Print Chainlink Image Built
         run: |
           echo "### chainlink image tag used for this test run :link:" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   build_chainlink_image:
     name: Build Chainlink Image
-    runs-on: ubuntu-latest-arm64
+    runs-on: ubuntu-24.04-arm
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     environment: integration

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -174,7 +174,7 @@ jobs:
           aws_registries: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
           test_command_to_run: nix develop -c sh -c "make test-integration-smoke-ci"
           test_download_vendor_packages_command: cd integration-tests && nix develop -c go mod download
-          cl_repo: ${{ env.CL_ECR }}
+          cl_repo: ${{ env.CL_ECR }}/chainlink
           cl_image_tag: starknet.${{ github.sha }}
           token: ${{ secrets.GITHUB_TOKEN }}
           go_mod_path: ./integration-tests/go.mod
@@ -190,6 +190,6 @@ jobs:
           enable-gap: false
         env:
           KILLGRAVE_INTERNAL_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/friendsofgo/killgrave
-          CHAINLINK_IMAGE: ${{ env.CL_ECR }}
+          CHAINLINK_IMAGE: ${{ env.CL_ECR }}/chainlink
           CHAINLINK_VERSION: starknet.${{ github.sha }}
           CHAINLINK_USER_TEAM: ${{ github.event.inputs.team || 'BIX' }}

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -28,7 +28,7 @@ env:
 jobs:
   build_chainlink_image:
     name: Build Chainlink Image
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-arm64
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     environment: integration

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -20,10 +20,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
+  # for PR builds, ${{ github.sha }} is the temporary merge commit, we want the head commit instead
+  SN_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
   TEST_LOG_LEVEL: debug
   CL_ECR: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
-  ENV_JOB_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-starknet-tests:${{ github.sha }}
-  GAUNTLET_PP_IMAGE: ${{ secrets.PROD_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.PROD_AWS_REGION }}.amazonaws.com/gauntlet-plus-plus:v2.5.0
 
 jobs:
   build_chainlink_image:
@@ -41,7 +41,7 @@ jobs:
         uses: smartcontractkit/chainlink-github-actions/docker/image-exists@fc3e0df622521019f50d772726d6bf8dc919dd38 # v2.3.19
         with:
           repository: chainlink
-          tag: starknet.${{ github.sha }}
+          tag: starknet.${{ env.SN_SHA }}
           AWS_REGION: ${{ secrets.QA_AWS_REGION }}
           AWS_ROLE_TO_ASSUME: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
       - name: Get core ref from PR body
@@ -69,9 +69,6 @@ jobs:
           persist-credentials: false
       - name: Build Image
         if: steps.check-image.outputs.exists == 'false'
-        env:
-          # for PR builds, ${{ github.sha }} is the temporary merge commit, we want the head commit instead
-          SN_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         uses: smartcontractkit/.github/actions/ctf-build-image@1d86ef6568d0830d212fc0091d352170dae07dc7 # v1.2.0
         with:
           platform: "linux/arm64"
@@ -178,7 +175,7 @@ jobs:
           test_command_to_run: nix develop -c sh -c "make test-integration-smoke-ci"
           test_download_vendor_packages_command: cd integration-tests && nix develop -c go mod download
           cl_repo: ${{ env.CL_ECR }}/chainlink
-          cl_image_tag: starknet.${{ github.sha }}
+          cl_image_tag: starknet.${{ env.SN_SHA }}
           token: ${{ secrets.GITHUB_TOKEN }}
           go_mod_path: ./integration-tests/go.mod
           QA_AWS_REGION: ${{ secrets.QA_AWS_REGION }}
@@ -194,5 +191,5 @@ jobs:
         env:
           KILLGRAVE_INTERNAL_IMAGE: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/friendsofgo/killgrave
           CHAINLINK_IMAGE: ${{ env.CL_ECR }}/chainlink
-          CHAINLINK_VERSION: starknet.${{ github.sha }}
-          CHAINLINK_USER_TEAM: ${{ github.event.inputs.team || 'BIX' }}
+          CHAINLINK_VERSION: starknet.${{ env.SN_SHA }}
+          CHAINLINK_USER_TEAM: ${{ github.event.inputs.team || 'DF' }}

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -84,7 +84,7 @@ jobs:
       - name: Build Image
         id: build-core
         if: steps.check-image.outputs.exists == 'false'
-        uses: smartcontractkit/.github/actions/ctf-build-image@888ae94cccb075c19526aa9ccd9b1d0a4a52b62b # v1.3.0
+        uses: smartcontractkit/.github/actions/ctf-build-image@61c6a8d174fcae10d436cc38c577f962396babbe # v1.3.0
         with:
           platform: ${{ matrix.platform }}
           dockerfile: plugins/chainlink.Dockerfile

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -69,23 +69,26 @@ jobs:
           persist-credentials: false
       - name: Build Image
         if: steps.check-image.outputs.exists == 'false'
+        env:
+          # for PR builds, ${{ github.sha }} is the temporary merge commit, we want the head commit instead
+          SN_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
         uses: smartcontractkit/.github/actions/ctf-build-image@1d86ef6568d0830d212fc0091d352170dae07dc7 # v1.2.0
         with:
           platform: "linux/arm64"
           dockerfile: plugins/chainlink.Dockerfile
           plugin-manifest-overrides: |
-            starknet=${{ github.event.pull_request.head.sha || github.sha }}
+            starknet=${{ env.SN_SHA }}
           # registry info
           docker-registry-url: ${{ env.CL_ECR }}
           docker-repository-name: chainlink
-          image-tag: starknet.${{ github.sha }}
+          image-tag: starknet.${{ env.SN_SHA }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
           aws-role-arn: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           aws-account-number: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
       - name: Print Chainlink Image Built
         run: |
           echo "### chainlink image tag used for this test run :link:" >> $GITHUB_STEP_SUMMARY
-          echo "\`starknet.${{ github.sha }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "\`starknet.${{ env.SN_SHA }}\`" >> $GITHUB_STEP_SUMMARY
 
   build_test_image:
     environment: integration

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -26,15 +26,29 @@ env:
   CL_ECR: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com
 
 jobs:
-  build_chainlink_image:
+  build_chainlink_images:
     name: Build Chainlink Image
-    runs-on: ubuntu-24.04-arm
+    strategy:
+      matrix:
+        include:
+          - platform: "linux/arm64"
+            runner: ubuntu-24.04-arm
+            arch: arm64
+          - platform: "linux/amd64"
+            runner: ubuntu-24.04
+            arch: amd64
+    runs-on: ${{ matrix.runner }}
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     environment: integration
     permissions:
       id-token: write
       contents: read
+    outputs:
+      docker-image-sha-digest-arm64:
+        ${{ steps.build-core.outputs.docker-image-sha-digest-arm64 }}
+      docker-image-sha-digest-amd64:
+        ${{ steps.build-core.outputs.docker-image-sha-digest-amd64 }}
     steps:
       - name: Check if chainlink-starknet image exists
         id: check-image
@@ -68,24 +82,55 @@ jobs:
           ref: ${{ env.CUSTOM_CORE_REF }}
           persist-credentials: false
       - name: Build Image
+        id: build-core
         if: steps.check-image.outputs.exists == 'false'
-        uses: smartcontractkit/.github/actions/ctf-build-image@1d86ef6568d0830d212fc0091d352170dae07dc7 # v1.2.0
+        uses: smartcontractkit/.github/actions/ctf-build-image@888ae94cccb075c19526aa9ccd9b1d0a4a52b62b # v1.3.0
         with:
-          platform: "linux/arm64"
+          platform: ${{ matrix.platform }}
           dockerfile: plugins/chainlink.Dockerfile
           plugin-manifest-overrides: |
             starknet=${{ env.SN_SHA }}
           # registry info
           docker-registry-url: ${{ env.CL_ECR }}
           docker-repository-name: chainlink
-          image-tag: starknet.${{ env.SN_SHA }}
+          image-tag: starknet.${{ env.SN_SHA }}-${{ matrix.arch }}
           aws-region: ${{ secrets.QA_AWS_REGION }}
           aws-role-arn: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
           aws-account-number: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
       - name: Print Chainlink Image Built
         run: |
           echo "### chainlink image tag used for this test run :link:" >> $GITHUB_STEP_SUMMARY
-          echo "\`starknet.${{ env.SN_SHA }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "\`starknet.${{ env.SN_SHA }}-${{ matrix.arch }}\`" >> $GITHUB_STEP_SUMMARY
+ 
+  build_multiplatform_image:
+    name: Build Multi-Platform Chainlink Image
+    needs: build_chainlink_images
+    environment: integration
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: smartcontractkit/.github/actions/build-push-docker-manifest@ce87497eb287565c796a8a781508be949f3ed1e2 # build-push-docker@1.0.0
+        with:
+          # Used for verifying the image signed with cosign.
+          cosign-oidc-identity-regexp: "^https://github.com/smartcontractkit/.*$"
+          docker-registry-url: ${{ env.CL_ECR }}
+          docker-repository-name: chainlink
+          docker-manifest-sign: true
+          docker-manifest-tag: starknet.${{ env.SN_SHA }}
+          docker-image-name-digests: >-
+            ${{
+              format(
+                '{0},{1}',
+                needs.build_chainlink_images.outputs.docker-image-sha-digest-amd64,
+                needs.build_chainlink_images.outputs.docker-image-sha-digest-arm64
+              )
+            }}
+          aws-region: ${{ secrets.QA_AWS_REGION }}
+          aws-role-arn: ${{ secrets.QA_AWS_ROLE_TO_ASSUME }}
+          aws-account-number: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}
+
 
   build_test_image:
     environment: integration
@@ -118,7 +163,7 @@ jobs:
   run_tests:
     name: Run Smoke Tests
     runs-on: ubuntu24.04-16cores-64GB
-    needs: [build_chainlink_image, build_test_image]
+    needs: [build_multiplatform_image, build_test_image]
     environment: integration
     env:
       INTERNAL_DOCKER_REPO: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com


### PR DESCRIPTION
This enables building and testing Chainlink images for both ARM64 and AMD64 architectures. The chainlink stage/prod environments now use arm64 nodes only , but CI tests still depend on AMD64 images so we have to build both. The PR was pointing to some feature branches but now that that the changes have been merged to the main branch of the .github actions repository we can merge these changes in.

I cleaned up the action also to tag the starknet image with the PR commit hash instead of the merged git hash which is confusing since it does not exist and cannot be fetched outside of the initial PR trigger.

After these changes are merged, we'll need to rebase Dimitris's starknet changes and attempt the rollout again. 

Here is evidence the build works in staging without a failed ArgoCD rollout: https://github.com/smartcontractkit/infra-k8s/pull/32462 

Co-pilot's summary of changes:

## Multi-platform Docker builds:
* Changed from single build_chainlink_image job to build_chainlink_images with matrix strategy
* Added support for both linux/arm64 and linux/amd64 platforms
* Uses different runners: ubuntu-24.04-arm for ARM64, ubuntu-24.04 for AMD64

## New multi-platform manifest job:
* Added build_multiplatform_image job that combines ARM64 and AMD64 images into a single manifest
* Uses build-push-docker-manifest action to create unified image

## SHA handling improvements:
* Added SN_SHA environment variable that properly uses PR head SHA instead of merge commit
* Updated all image tags to use SN_SHA instead of github.sha

## Build action upgrade:
* Updated from older ctf-build-image@v0.1.3 to @v1.3.0
* Changed from legacy parameters to new platform, dockerfile, plugin-manifest-overrides format

## Job dependencies updated:
* run_tests now depends on build_multiplatform_image instead of build_chainlink_image
