### PR TITLE
fix(security): add explicit workflow permissions

### DIFF
--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -6,14 +6,16 @@ on:
       - main
 
 permissions:
-  contents: write
-  pull-requests: write
-  actions: write
+  contents: read
 
 jobs:
   changesets:
     name: Changesets
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+      actions: write
     steps:
       # Checkout this repository
       - name: Checkout Repo

--- a/.github/workflows/changesets.yml
+++ b/.github/workflows/changesets.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
 
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
 jobs:
   changesets:
     name: Changesets

--- a/.github/workflows/contracts.yml
+++ b/.github/workflows/contracts.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   contracts_run_ts_tests:
     name: Run Typescript Tests

--- a/.github/workflows/examples.yml
+++ b/.github/workflows/examples.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   run_examples_tests:
     name: Run Tests

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -3,6 +3,9 @@ name: golangci_lint
 on:
   push:
 
+permissions:
+  contents: read
+
 jobs:
   golangci-lint-version:
     name: Get golangci-lint version to from nix

--- a/.github/workflows/integration-tests-publish.yml
+++ b/.github/workflows/integration-tests-publish.yml
@@ -6,6 +6,9 @@ on:
     branches:
       - develop
 
+permissions:
+  contents: read
+
 env:
   ECR_TAG: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink-starknet-tests:develop
 

--- a/.github/workflows/integration-tests-smoke.yml
+++ b/.github/workflows/integration-tests-smoke.yml
@@ -19,6 +19,9 @@ concurrency:
   group: integration-tests-starknet-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   # for PR builds, ${{ github.sha }} is the temporary merge commit, we want the head commit instead
   SN_SHA: ${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/integration-tests-soak.yml
+++ b/.github/workflows/integration-tests-soak.yml
@@ -20,6 +20,9 @@ on:
         required: true
         type: string
 
+permissions:
+  contents: read
+
 env:
   TEST_LOG_LEVEL: debug
   CL_ECR: ${{ secrets.QA_AWS_ACCOUNT_NUMBER }}.dkr.ecr.${{ secrets.QA_AWS_REGION }}.amazonaws.com/chainlink

--- a/.github/workflows/integration_gauntlet.yml
+++ b/.github/workflows/integration_gauntlet.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   gauntlet_eslint:
     name: Gauntlet ESLint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   lint_format_check:
     name: Format Check

--- a/.github/workflows/monitoring-build-push-ecr.yml
+++ b/.github/workflows/monitoring-build-push-ecr.yml
@@ -8,6 +8,9 @@ on:
       - monitoring/**
       - relayer/**
 
+permissions:
+  contents: read
+
 jobs:
   build-and-publish-monitoring:
     runs-on: ubuntu-latest

--- a/.github/workflows/relayer.yml
+++ b/.github/workflows/relayer.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   relayer_run_unit_tests:
     name: Run Unit Tests ${{ matrix.test-type.name }}

--- a/.github/workflows/release/starknet-gauntlet-cli.yml
+++ b/.github/workflows/release/starknet-gauntlet-cli.yml
@@ -3,10 +3,15 @@ name: Starknet Gauntlet CLI Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   starknet-gauntlet-cli-release:
     name: Starknet Gauntlet CLI Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Checkout this repository
       - name: Checkout Repo

--- a/.github/workflows/release/starknet-relayer.yml
+++ b/.github/workflows/release/starknet-relayer.yml
@@ -3,10 +3,15 @@ name: Starknet Relayer Release
 on:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   starknet-relayer-release:
     name: Release Starknet Relayer
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       # Checkout this repository
       - name: Checkout Repo

--- a/.github/workflows/sonar-scan.yml
+++ b/.github/workflows/sonar-scan.yml
@@ -3,6 +3,9 @@ name: SonarQube Scan
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   wait_for_workflows:
     name: Wait for workflows

--- a/.github/workflows/static-analysis.yml
+++ b/.github/workflows/static-analysis.yml
@@ -7,6 +7,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   zizmor_analyzer:
     name: Zizmor


### PR DESCRIPTION
## Summary
Adds explicit `permissions` blocks to all workflow YAML files to resolve CodeQL `actions/missing-workflow-permissions` alerts (~12 alerts).

## Changes
- **Read-only workflows**: Added `permissions: { contents: read }` to static-analysis, sonar-scan, lint, relayer, integration_gauntlet, integration-tests-soak, integration-tests-smoke, integration-tests-publish, monitoring-build-push-ecr, golangci-lint, examples, contracts
- **Release workflows**: Added workflow-level `contents: read` and job-level `contents: write` for starknet-relayer and starknet-gauntlet-cli release workflows
- **Changesets**: Added `contents: write`, `pull-requests: write`, `actions: write` (required for creating release PRs and dispatching workflows)

## Scope
Workflow-only changes. Code alerts are handled in a separate PR.

Made with [Cursor](https://cursor.com)