### PR TITLE
fix(monitoring): bump Dockerfile Go to 1.26.2 for STOM ECR build

### DIFF
--- a/monitoring/ops/Dockerfile
+++ b/monitoring/ops/Dockerfile
@@ -1,5 +1,5 @@
 # Build image
-FROM golang:1.25.3 as build
+FROM golang:1.26.2 as build
 
 # Copy source
 


### PR DESCRIPTION
## Summary

- Bump `monitoring/ops/Dockerfile` base image from `golang:1.25.3` to `golang:1.26.2`
- Unblocks the STOM ECR publish workflow that failed on #695 merge (`go.mod requires go >= 1.26.2`):
Failed run:
https://github.com/smartcontractkit/chainlink-starknet/actions/runs/27641155136/job/81741224935

## Test plan

- [ ] Merge to `develop` and confirm `monitoring-build-push-ecr.yml` publishes `sha-62867c3ee637ca531c081f4c62b82d2dcd7b09c6` to ECR
- [ ] Then merge infra-k8s #39437 to roll prod testnet STOM