### PR TITLE
fix(ocr2): restore low-bit round ID decode for STOM proxy feeds

### DIFF
--- a/relayer/pkg/chainlink/ocr2/types.go
+++ b/relayer/pkg/chainlink/ocr2/types.go
@@ -60,10 +60,11 @@ func NewRoundData(felts []*felt.Felt) (data RoundData, err error) {
 		return data, fmt.Errorf("expected number of felts to be 5 but got %d", len(felts))
 	}
 	roundID := felts[0].BigInt(big.NewInt(0))
-	if !roundID.IsUint64() && roundID.Uint64() > math.MaxUint32 {
+	roundID64 := roundID.Uint64()
+	if roundID64 > math.MaxUint32 {
 		return data, fmt.Errorf("aggregator round id does not fit in a uint32 '%s'", felts[0].String())
 	}
-	data.RoundID = uint32(roundID.Uint64())
+	data.RoundID = uint32(roundID64)
 	data.Answer = felts[1].BigInt(big.NewInt(0))
 	blockNumber := felts[2].BigInt(big.NewInt(0))
 	if !blockNumber.IsUint64() {

--- a/relayer/pkg/chainlink/ocr2/types.go
+++ b/relayer/pkg/chainlink/ocr2/types.go
@@ -55,36 +55,15 @@ type RoundData struct {
 	UpdatedAt   time.Time
 }
 
-var feltLowU128Mask = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
-
-// splitFelt mirrors chainlink::utils::split_felt (u128s_from_felt252).
-func splitFelt(f *felt.Felt) (high, low *big.Int) {
-	n := f.BigInt(new(big.Int))
-	low = new(big.Int).And(n, feltLowU128Mask)
-	high = new(big.Int).Rsh(new(big.Int).Set(n), 128)
-	return high, low
-}
-
-func roundIDFromFelt(f *felt.Felt) (uint32, error) {
-	_, low := splitFelt(f)
-	if !low.IsUint64() {
-		return 0, fmt.Errorf("aggregator round id does not fit in a uint64 '%s'", f.String())
-	}
-	roundID64 := low.Uint64()
-	if roundID64 > math.MaxUint32 {
-		return 0, fmt.Errorf("aggregator round id does not fit in a uint32 '%s'", f.String())
-	}
-	return uint32(roundID64), nil
-}
-
 func NewRoundData(felts []*felt.Felt) (data RoundData, err error) {
 	if len(felts) != 5 {
 		return data, fmt.Errorf("expected number of felts to be 5 but got %d", len(felts))
 	}
-	data.RoundID, err = roundIDFromFelt(felts[0])
-	if err != nil {
-		return data, err
+	roundID := felts[0].BigInt(big.NewInt(0))
+	if !roundID.IsUint64() && roundID.Uint64() > math.MaxUint32 {
+		return data, fmt.Errorf("aggregator round id does not fit in a uint32 '%s'", felts[0].String())
 	}
+	data.RoundID = uint32(roundID.Uint64())
 	data.Answer = felts[1].BigInt(big.NewInt(0))
 	blockNumber := felts[2].BigInt(big.NewInt(0))
 	if !blockNumber.IsUint64() {

--- a/relayer/pkg/chainlink/ocr2/types.go
+++ b/relayer/pkg/chainlink/ocr2/types.go
@@ -55,19 +55,36 @@ type RoundData struct {
 	UpdatedAt   time.Time
 }
 
+var feltLowU128Mask = new(big.Int).Sub(new(big.Int).Lsh(big.NewInt(1), 128), big.NewInt(1))
+
+// splitFelt mirrors chainlink::utils::split_felt (u128s_from_felt252).
+func splitFelt(f *felt.Felt) (high, low *big.Int) {
+	n := f.BigInt(new(big.Int))
+	low = new(big.Int).And(n, feltLowU128Mask)
+	high = new(big.Int).Rsh(new(big.Int).Set(n), 128)
+	return high, low
+}
+
+func roundIDFromFelt(f *felt.Felt) (uint32, error) {
+	_, low := splitFelt(f)
+	if !low.IsUint64() {
+		return 0, fmt.Errorf("aggregator round id does not fit in a uint64 '%s'", f.String())
+	}
+	roundID64 := low.Uint64()
+	if roundID64 > math.MaxUint32 {
+		return 0, fmt.Errorf("aggregator round id does not fit in a uint32 '%s'", f.String())
+	}
+	return uint32(roundID64), nil
+}
+
 func NewRoundData(felts []*felt.Felt) (data RoundData, err error) {
 	if len(felts) != 5 {
 		return data, fmt.Errorf("expected number of felts to be 5 but got %d", len(felts))
 	}
-	roundID := felts[0].BigInt(big.NewInt(0))
-	if !roundID.IsUint64() {
-		return data, fmt.Errorf("aggregator round id does not fit in a uint64 '%s'", felts[0].String())
+	data.RoundID, err = roundIDFromFelt(felts[0])
+	if err != nil {
+		return data, err
 	}
-	roundID64 := felts[0].BigInt(big.NewInt(0)).Uint64()
-	if roundID64 > math.MaxUint32 {
-		return data, fmt.Errorf("aggregator round id does not fit in a uint32 '%s'", felts[0].String())
-	}
-	data.RoundID = uint32(roundID64)
 	data.Answer = felts[1].BigInt(big.NewInt(0))
 	blockNumber := felts[2].BigInt(big.NewInt(0))
 	if !blockNumber.IsUint64() {

--- a/relayer/pkg/chainlink/ocr2/types_test.go
+++ b/relayer/pkg/chainlink/ocr2/types_test.go
@@ -32,6 +32,67 @@ func TestNewRoundData(t *testing.T) {
 	require.Equal(t, expectedRound, actualRound)
 }
 
+func TestNewRoundData_ProxyPhasePrefixedRoundID(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name          string
+		roundIDHex    string
+		expectedRound uint32
+	}{
+		{
+			name:          "DAI/USD phase 1",
+			roundIDHex:    "0x100000000000000000000000000010c80",
+			expectedRound: 0x10c80,
+		},
+		{
+			name:          "USDC/USD phase 1",
+			roundIDHex:    "0x10000000000000000000000000001192e",
+			expectedRound: 0x1192e,
+		},
+		{
+			name:          "ETH/USD phase 1",
+			roundIDHex:    "0x10000000000000000000000000001664b",
+			expectedRound: 0x1664b,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			raw := []string{
+				tc.roundIDHex,
+				"0x5f5e100",
+				"0x1087",
+				"0x633344a3",
+				"0x633344a5",
+			}
+			felts, err := starknetutils.HexArrToFelt(raw)
+			require.NoError(t, err)
+
+			actualRound, err := NewRoundData(felts)
+			require.NoError(t, err)
+			require.Equal(t, tc.expectedRound, actualRound.RoundID)
+		})
+	}
+}
+
+func TestRoundIDFromFelt(t *testing.T) {
+	t.Parallel()
+
+	f, err := starknetutils.HexToFelt("0x100000000000000000000000000010c80")
+	require.NoError(t, err)
+
+	high, low := splitFelt(f)
+	require.Equal(t, uint64(1), high.Uint64())
+	require.Equal(t, uint64(0x10c80), low.Uint64())
+
+	roundID, err := roundIDFromFelt(f)
+	require.NoError(t, err)
+	require.Equal(t, uint32(0x10c80), roundID)
+}
+
 // Helpers
 
 func bigIntFromString(s string) *big.Int {

--- a/relayer/pkg/chainlink/ocr2/types_test.go
+++ b/relayer/pkg/chainlink/ocr2/types_test.go
@@ -78,21 +78,6 @@ func TestNewRoundData_ProxyPhasePrefixedRoundID(t *testing.T) {
 	}
 }
 
-func TestRoundIDFromFelt(t *testing.T) {
-	t.Parallel()
-
-	f, err := starknetutils.HexToFelt("0x100000000000000000000000000010c80")
-	require.NoError(t, err)
-
-	high, low := splitFelt(f)
-	require.Equal(t, uint64(1), high.Uint64())
-	require.Equal(t, uint64(0x10c80), low.Uint64())
-
-	roundID, err := roundIDFromFelt(f)
-	require.NoError(t, err)
-	require.Equal(t, uint32(0x10c80), roundID)
-}
-
 // Helpers
 
 func bigIntFromString(s string) *big.Int {


### PR DESCRIPTION
## Summary
- Revert the #345 `IsUint64()` guard on `NewRoundData` that broke STOM `proxy` source polling
- AggregatorProxy encodes `round_id` as phase in high bits + aggregator round in low bits; restore pre-#345 behaviour using `Uint64()` low bits
- Fixes prod testnet errors: `aggregator round id does not fit in a uint64`

## Test plan
- [x] `go test ./relayer/pkg/chainlink/ocr2/... -run TestNewRoundData`
- [ ] Merge to `develop`, confirm STOM ECR build publishes
- [ ] Bump STOM image tag in infra-k8s and verify proxy source errors clear