### PR TITLE
fix(txm): delete nonceBroadcastCounts on tx confirmation

### DIFF
--- a/relayer/pkg/chainlink/txm/txm.go
+++ b/relayer/pkg/chainlink/txm/txm.go
@@ -446,6 +446,7 @@ func (txm *starktxm) confirmLoop() {
 						} else {
 							txm.lggr.Warnw("No broadcast time found for confirmed transaction", "accountAddress", accountAddress, "nonce", nonceStr)
 						}
+						txm.nonceBroadcastCounts.Delete(nonceStr)
 					}
 				}
 


### PR DESCRIPTION
## Summary
- Delete `nonceBroadcastCounts` entries in the TXM confirm loop when a transaction is confirmed
- Matches existing cleanup for `broadcastTimes` on the same path

## Problem
`nonceBroadcastCounts` was populated on every broadcast but only deleted during nonce resync/stale-tx handling. On a normal OCR transmitter node, one map entry accumulated per confirmed transmission for the process lifetime.

Introduced in chainlink-starknet #655 (merged 2025-11-28); first shipped in chainlink core via plugin bump #20490 (2025-12-03, ref `0051d73c`).

## Test plan
- [x] `go test ./relayer/pkg/chainlink/txm/...`
- [ ] Merge and bump chainlink `plugins.public.yaml` starknet ref when ready